### PR TITLE
Simplify font fallbacks and use Maps for configuration

### DIFF
--- a/demos/BentonSans.html
+++ b/demos/BentonSans.html
@@ -3,16 +3,16 @@
 <!--[if IE 8]>         <html class="o-useragent-ie8 o-hoverable-on"> <![endif]-->
 <!--[if gt IE 8]><!--> <html class="o-hoverable-on"> <!--<![endif]-->
 <head>
-    <meta charset="utf-8" />
-    <title>o-fonts: BentonSans demo</title>
-    <meta name="viewport" content="initial-scale=1.0, width=device-width" />
-    <script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
-    <style>body { margin: 0; }.demo-js .o--if-nojs { display: none; }</style>
-    <link rel="stylesheet" href="/bundles/css?modules=o-fonts:/demos/src/demo.scss" />
+	<meta charset="utf-8" />
+	<title>o-fonts: BentonSans demo</title>
+	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
+	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
+	<style>body { margin: 0; } .demo-js .o--if-nojs { display: none; }</style>
+	<script>(function(d) { d.className = d.className + ' demo-js'; })(document.documentElement);</script>
+	<link rel="stylesheet" href="/bundles/css?modules=o-fonts:/demos/src/demo.scss" />
 </head>
 <body class="">
-    <script>(function(d) {var b = d.getElementsByTagName('body')[0];b.className = b.className + ' demo-js';})(document);</script>
-    <div class="demo-container demo-family-bentonsans">
+<div class="demo-container demo-family-bentonsans">
 
 	<div class="demo-row">
 		<div class="demo-col">
@@ -32,7 +32,7 @@
 	</div>
 
 </div>
-    
-    <script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>
+
+<script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>
 </body>
 </html>

--- a/demos/Clarion.html
+++ b/demos/Clarion.html
@@ -3,16 +3,16 @@
 <!--[if IE 8]>         <html class="o-useragent-ie8 o-hoverable-on"> <![endif]-->
 <!--[if gt IE 8]><!--> <html class="o-hoverable-on"> <!--<![endif]-->
 <head>
-    <meta charset="utf-8" />
-    <title>o-fonts: Clarion demo</title>
-    <meta name="viewport" content="initial-scale=1.0, width=device-width" />
-    <script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
-    <style>body { margin: 0; }.demo-js .o--if-nojs { display: none; }</style>
-    <link rel="stylesheet" href="/bundles/css?modules=o-fonts:/demos/src/demo.scss" />
+	<meta charset="utf-8" />
+	<title>o-fonts: Clarion demo</title>
+	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
+	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
+	<style>body { margin: 0; } .demo-js .o--if-nojs { display: none; }</style>
+	<script>(function(d) { d.className = d.className + ' demo-js'; })(document.documentElement);</script>
+	<link rel="stylesheet" href="/bundles/css?modules=o-fonts:/demos/src/demo.scss" />
 </head>
 <body class="">
-    <script>(function(d) {var b = d.getElementsByTagName('body')[0];b.className = b.className + ' demo-js';})(document);</script>
-    <div class="demo-container demo-family-clarion">
+<div class="demo-container demo-family-clarion">
 
 	<div class="demo-row">
 		<div class="demo-col">
@@ -32,7 +32,7 @@
 	</div>
 
 </div>
-    
-    <script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>
+
+<script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>
 </body>
 </html>

--- a/demos/MillerDisplay.html
+++ b/demos/MillerDisplay.html
@@ -3,16 +3,16 @@
 <!--[if IE 8]>         <html class="o-useragent-ie8 o-hoverable-on"> <![endif]-->
 <!--[if gt IE 8]><!--> <html class="o-hoverable-on"> <!--<![endif]-->
 <head>
-    <meta charset="utf-8" />
-    <title>o-fonts: MillerDisplay demo</title>
-    <meta name="viewport" content="initial-scale=1.0, width=device-width" />
-    <script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
-    <style>body { margin: 0; }.demo-js .o--if-nojs { display: none; }</style>
-    <link rel="stylesheet" href="/bundles/css?modules=o-fonts:/demos/src/demo.scss" />
+	<meta charset="utf-8" />
+	<title>o-fonts: MillerDisplay demo</title>
+	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
+	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
+	<style>body { margin: 0; } .demo-js .o--if-nojs { display: none; }</style>
+	<script>(function(d) { d.className = d.className + ' demo-js'; })(document.documentElement);</script>
+	<link rel="stylesheet" href="/bundles/css?modules=o-fonts:/demos/src/demo.scss" />
 </head>
 <body class="">
-    <script>(function(d) {var b = d.getElementsByTagName('body')[0];b.className = b.className + ' demo-js';})(document);</script>
-    <div class="demo-container demo-family-millerdisplay">
+<div class="demo-container demo-family-millerdisplay">
 
 	<div class="demo-row">
 		<div class="demo-col">
@@ -32,7 +32,7 @@
 	</div>
 
 </div>
-    
-    <script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>
+
+<script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>
 </body>
 </html>

--- a/demos/bentonsans-bold.html
+++ b/demos/bentonsans-bold.html
@@ -3,16 +3,16 @@
 <!--[if IE 8]>         <html class="o-useragent-ie8 o-hoverable-on"> <![endif]-->
 <!--[if gt IE 8]><!--> <html class="o-hoverable-on"> <!--<![endif]-->
 <head>
-    <meta charset="utf-8" />
-    <title>o-fonts: bentonsans-bold demo</title>
-    <meta name="viewport" content="initial-scale=1.0, width=device-width" />
-    <script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
-    <style>body { margin: 0; }.demo-js .o--if-nojs { display: none; }</style>
-    <link rel="stylesheet" href="/bundles/css?modules=o-fonts:/demos/src/demo.scss" />
+	<meta charset="utf-8" />
+	<title>o-fonts: bentonsans-bold demo</title>
+	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
+	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
+	<style>body { margin: 0; } .demo-js .o--if-nojs { display: none; }</style>
+	<script>(function(d) { d.className = d.className + ' demo-js'; })(document.documentElement);</script>
+	<link rel="stylesheet" href="/bundles/css?modules=o-fonts:/demos/src/demo.scss" />
 </head>
 <body class="">
-    <script>(function(d) {var b = d.getElementsByTagName('body')[0];b.className = b.className + ' demo-js';})(document);</script>
-    <div class="demo-container demo-bentonsans-bold">
+<div class="demo-container demo-bentonsans-bold">
 
 	<div class="demo-row">
 		<div class="demo-col">
@@ -32,7 +32,7 @@
 
 </div>
 
-    
-    <script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>
+
+<script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>
 </body>
 </html>

--- a/demos/bentonsans-lighter.html
+++ b/demos/bentonsans-lighter.html
@@ -3,16 +3,16 @@
 <!--[if IE 8]>         <html class="o-useragent-ie8 o-hoverable-on"> <![endif]-->
 <!--[if gt IE 8]><!--> <html class="o-hoverable-on"> <!--<![endif]-->
 <head>
-    <meta charset="utf-8" />
-    <title>o-fonts: bentonsans-lighter demo</title>
-    <meta name="viewport" content="initial-scale=1.0, width=device-width" />
-    <script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
-    <style>body { margin: 0; }.demo-js .o--if-nojs { display: none; }</style>
-    <link rel="stylesheet" href="/bundles/css?modules=o-fonts:/demos/src/demo.scss" />
+	<meta charset="utf-8" />
+	<title>o-fonts: bentonsans-lighter demo</title>
+	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
+	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
+	<style>body { margin: 0; } .demo-js .o--if-nojs { display: none; }</style>
+	<script>(function(d) { d.className = d.className + ' demo-js'; })(document.documentElement);</script>
+	<link rel="stylesheet" href="/bundles/css?modules=o-fonts:/demos/src/demo.scss" />
 </head>
 <body class="">
-    <script>(function(d) {var b = d.getElementsByTagName('body')[0];b.className = b.className + ' demo-js';})(document);</script>
-    <div class="demo-container demo-bentonsans-lighter">
+<div class="demo-container demo-bentonsans-lighter">
 
 	<div class="demo-row">
 		<div class="demo-col">
@@ -32,7 +32,7 @@
 
 </div>
 
-    
-    <script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>
+
+<script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>
 </body>
 </html>

--- a/demos/bentonsans-normal.html
+++ b/demos/bentonsans-normal.html
@@ -3,16 +3,16 @@
 <!--[if IE 8]>         <html class="o-useragent-ie8 o-hoverable-on"> <![endif]-->
 <!--[if gt IE 8]><!--> <html class="o-hoverable-on"> <!--<![endif]-->
 <head>
-    <meta charset="utf-8" />
-    <title>o-fonts: bentonsans-normal demo</title>
-    <meta name="viewport" content="initial-scale=1.0, width=device-width" />
-    <script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
-    <style>body { margin: 0; }.demo-js .o--if-nojs { display: none; }</style>
-    <link rel="stylesheet" href="/bundles/css?modules=o-fonts:/demos/src/demo.scss" />
+	<meta charset="utf-8" />
+	<title>o-fonts: bentonsans-normal demo</title>
+	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
+	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
+	<style>body { margin: 0; } .demo-js .o--if-nojs { display: none; }</style>
+	<script>(function(d) { d.className = d.className + ' demo-js'; })(document.documentElement);</script>
+	<link rel="stylesheet" href="/bundles/css?modules=o-fonts:/demos/src/demo.scss" />
 </head>
 <body class="">
-    <script>(function(d) {var b = d.getElementsByTagName('body')[0];b.className = b.className + ' demo-js';})(document);</script>
-    <div class="demo-container demo-bentonsans-normal">
+<div class="demo-container demo-bentonsans-normal">
 
 	<div class="demo-row">
 		<div class="demo-col">
@@ -32,7 +32,7 @@
 
 </div>
 
-    
-    <script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>
+
+<script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>
 </body>
 </html>

--- a/demos/clarion-bold.html
+++ b/demos/clarion-bold.html
@@ -3,16 +3,16 @@
 <!--[if IE 8]>         <html class="o-useragent-ie8 o-hoverable-on"> <![endif]-->
 <!--[if gt IE 8]><!--> <html class="o-hoverable-on"> <!--<![endif]-->
 <head>
-    <meta charset="utf-8" />
-    <title>o-fonts: clarion-bold demo</title>
-    <meta name="viewport" content="initial-scale=1.0, width=device-width" />
-    <script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
-    <style>body { margin: 0; }.demo-js .o--if-nojs { display: none; }</style>
-    <link rel="stylesheet" href="/bundles/css?modules=o-fonts:/demos/src/demo.scss" />
+	<meta charset="utf-8" />
+	<title>o-fonts: clarion-bold demo</title>
+	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
+	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
+	<style>body { margin: 0; } .demo-js .o--if-nojs { display: none; }</style>
+	<script>(function(d) { d.className = d.className + ' demo-js'; })(document.documentElement);</script>
+	<link rel="stylesheet" href="/bundles/css?modules=o-fonts:/demos/src/demo.scss" />
 </head>
 <body class="">
-    <script>(function(d) {var b = d.getElementsByTagName('body')[0];b.className = b.className + ' demo-js';})(document);</script>
-    <div class="demo-container demo-clarion-bold">
+<div class="demo-container demo-clarion-bold">
 
 	<div class="demo-row">
 		<div class="demo-col">
@@ -32,7 +32,7 @@
 
 </div>
 
-    
-    <script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>
+
+<script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>
 </body>
 </html>

--- a/demos/clarion-italic.html
+++ b/demos/clarion-italic.html
@@ -3,16 +3,16 @@
 <!--[if IE 8]>         <html class="o-useragent-ie8 o-hoverable-on"> <![endif]-->
 <!--[if gt IE 8]><!--> <html class="o-hoverable-on"> <!--<![endif]-->
 <head>
-    <meta charset="utf-8" />
-    <title>o-fonts: clarion-italic demo</title>
-    <meta name="viewport" content="initial-scale=1.0, width=device-width" />
-    <script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
-    <style>body { margin: 0; }.demo-js .o--if-nojs { display: none; }</style>
-    <link rel="stylesheet" href="/bundles/css?modules=o-fonts:/demos/src/demo.scss" />
+	<meta charset="utf-8" />
+	<title>o-fonts: clarion-italic demo</title>
+	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
+	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
+	<style>body { margin: 0; } .demo-js .o--if-nojs { display: none; }</style>
+	<script>(function(d) { d.className = d.className + ' demo-js'; })(document.documentElement);</script>
+	<link rel="stylesheet" href="/bundles/css?modules=o-fonts:/demos/src/demo.scss" />
 </head>
 <body class="">
-    <script>(function(d) {var b = d.getElementsByTagName('body')[0];b.className = b.className + ' demo-js';})(document);</script>
-    <div class="demo-container demo-clarion-italic">
+<div class="demo-container demo-clarion-italic">
 
 	<div class="demo-row">
 		<div class="demo-col">
@@ -32,7 +32,7 @@
 
 </div>
 
-    
-    <script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>
+
+<script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>
 </body>
 </html>

--- a/demos/clarion-normal.html
+++ b/demos/clarion-normal.html
@@ -3,16 +3,16 @@
 <!--[if IE 8]>         <html class="o-useragent-ie8 o-hoverable-on"> <![endif]-->
 <!--[if gt IE 8]><!--> <html class="o-hoverable-on"> <!--<![endif]-->
 <head>
-    <meta charset="utf-8" />
-    <title>o-fonts: clarion-normal demo</title>
-    <meta name="viewport" content="initial-scale=1.0, width=device-width" />
-    <script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
-    <style>body { margin: 0; }.demo-js .o--if-nojs { display: none; }</style>
-    <link rel="stylesheet" href="/bundles/css?modules=o-fonts:/demos/src/demo.scss" />
+	<meta charset="utf-8" />
+	<title>o-fonts: clarion-normal demo</title>
+	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
+	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
+	<style>body { margin: 0; } .demo-js .o--if-nojs { display: none; }</style>
+	<script>(function(d) { d.className = d.className + ' demo-js'; })(document.documentElement);</script>
+	<link rel="stylesheet" href="/bundles/css?modules=o-fonts:/demos/src/demo.scss" />
 </head>
 <body class="">
-    <script>(function(d) {var b = d.getElementsByTagName('body')[0];b.className = b.className + ' demo-js';})(document);</script>
-    <div class="demo-container demo-clarion-normal">
+<div class="demo-container demo-clarion-normal">
 
 	<div class="demo-row">
 		<div class="demo-col">
@@ -32,7 +32,7 @@
 
 </div>
 
-    
-    <script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>
+
+<script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>
 </body>
 </html>

--- a/demos/financierdisplay-italic.html
+++ b/demos/financierdisplay-italic.html
@@ -3,16 +3,16 @@
 <!--[if IE 8]>         <html class="o-useragent-ie8 o-hoverable-on"> <![endif]-->
 <!--[if gt IE 8]><!--> <html class="o-hoverable-on"> <!--<![endif]-->
 <head>
-    <meta charset="utf-8" />
-    <title>o-fonts: financierdisplay-italic demo</title>
-    <meta name="viewport" content="initial-scale=1.0, width=device-width" />
-    <script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
-    <style>body { margin: 0; }.demo-js .o--if-nojs { display: none; }</style>
-    <link rel="stylesheet" href="/bundles/css?modules=o-fonts:/demos/src/demo.scss" />
+	<meta charset="utf-8" />
+	<title>o-fonts: financierdisplay-italic demo</title>
+	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
+	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
+	<style>body { margin: 0; } .demo-js .o--if-nojs { display: none; }</style>
+	<script>(function(d) { d.className = d.className + ' demo-js'; })(document.documentElement);</script>
+	<link rel="stylesheet" href="/bundles/css?modules=o-fonts:/demos/src/demo.scss" />
 </head>
 <body class="">
-    <script>(function(d) {var b = d.getElementsByTagName('body')[0];b.className = b.className + ' demo-js';})(document);</script>
-    <div class="demo-container demo-financierdisplay-italic">
+<div class="demo-container demo-financierdisplay-italic">
 
 	<div class="demo-row">
 		<div class="demo-col">
@@ -32,7 +32,7 @@
 
 </div>
 
-    
-    <script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>
+
+<script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>
 </body>
 </html>

--- a/demos/financierdisplay-normal.html
+++ b/demos/financierdisplay-normal.html
@@ -3,16 +3,16 @@
 <!--[if IE 8]>         <html class="o-useragent-ie8 o-hoverable-on"> <![endif]-->
 <!--[if gt IE 8]><!--> <html class="o-hoverable-on"> <!--<![endif]-->
 <head>
-    <meta charset="utf-8" />
-    <title>o-fonts: financierdisplay-normal demo</title>
-    <meta name="viewport" content="initial-scale=1.0, width=device-width" />
-    <script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
-    <style>body { margin: 0; }.demo-js .o--if-nojs { display: none; }</style>
-    <link rel="stylesheet" href="/bundles/css?modules=o-fonts:/demos/src/demo.scss" />
+	<meta charset="utf-8" />
+	<title>o-fonts: financierdisplay-normal demo</title>
+	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
+	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
+	<style>body { margin: 0; } .demo-js .o--if-nojs { display: none; }</style>
+	<script>(function(d) { d.className = d.className + ' demo-js'; })(document.documentElement);</script>
+	<link rel="stylesheet" href="/bundles/css?modules=o-fonts:/demos/src/demo.scss" />
 </head>
 <body class="">
-    <script>(function(d) {var b = d.getElementsByTagName('body')[0];b.className = b.className + ' demo-js';})(document);</script>
-    <div class="demo-container demo-financierdisplay-normal">
+<div class="demo-container demo-financierdisplay-normal">
 
 	<div class="demo-row">
 		<div class="demo-col">
@@ -32,7 +32,7 @@
 
 </div>
 
-    
-    <script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>
+
+<script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>
 </body>
 </html>

--- a/demos/financiertext-italic.html
+++ b/demos/financiertext-italic.html
@@ -3,16 +3,16 @@
 <!--[if IE 8]>         <html class="o-useragent-ie8 o-hoverable-on"> <![endif]-->
 <!--[if gt IE 8]><!--> <html class="o-hoverable-on"> <!--<![endif]-->
 <head>
-    <meta charset="utf-8" />
-    <title>o-fonts: financiertext-italic demo</title>
-    <meta name="viewport" content="initial-scale=1.0, width=device-width" />
-    <script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
-    <style>body { margin: 0; }.demo-js .o--if-nojs { display: none; }</style>
-    <link rel="stylesheet" href="/bundles/css?modules=o-fonts:/demos/src/demo.scss" />
+	<meta charset="utf-8" />
+	<title>o-fonts: financiertext-italic demo</title>
+	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
+	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
+	<style>body { margin: 0; } .demo-js .o--if-nojs { display: none; }</style>
+	<script>(function(d) { d.className = d.className + ' demo-js'; })(document.documentElement);</script>
+	<link rel="stylesheet" href="/bundles/css?modules=o-fonts:/demos/src/demo.scss" />
 </head>
 <body class="">
-    <script>(function(d) {var b = d.getElementsByTagName('body')[0];b.className = b.className + ' demo-js';})(document);</script>
-    <div class="demo-container demo-financiertext-italic">
+<div class="demo-container demo-financiertext-italic">
 
 	<div class="demo-row">
 		<div class="demo-col">
@@ -32,7 +32,7 @@
 
 </div>
 
-    
-    <script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>
+
+<script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>
 </body>
 </html>

--- a/demos/financiertext-normal.html
+++ b/demos/financiertext-normal.html
@@ -3,16 +3,16 @@
 <!--[if IE 8]>         <html class="o-useragent-ie8 o-hoverable-on"> <![endif]-->
 <!--[if gt IE 8]><!--> <html class="o-hoverable-on"> <!--<![endif]-->
 <head>
-    <meta charset="utf-8" />
-    <title>o-fonts: financiertext-normal demo</title>
-    <meta name="viewport" content="initial-scale=1.0, width=device-width" />
-    <script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
-    <style>body { margin: 0; }.demo-js .o--if-nojs { display: none; }</style>
-    <link rel="stylesheet" href="/bundles/css?modules=o-fonts:/demos/src/demo.scss" />
+	<meta charset="utf-8" />
+	<title>o-fonts: financiertext-normal demo</title>
+	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
+	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
+	<style>body { margin: 0; } .demo-js .o--if-nojs { display: none; }</style>
+	<script>(function(d) { d.className = d.className + ' demo-js'; })(document.documentElement);</script>
+	<link rel="stylesheet" href="/bundles/css?modules=o-fonts:/demos/src/demo.scss" />
 </head>
 <body class="">
-    <script>(function(d) {var b = d.getElementsByTagName('body')[0];b.className = b.className + ' demo-js';})(document);</script>
-    <div class="demo-container demo-financiertext-normal">
+<div class="demo-container demo-financiertext-normal">
 
 	<div class="demo-row">
 		<div class="demo-col">
@@ -32,7 +32,7 @@
 
 </div>
 
-    
-    <script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>
+
+<script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>
 </body>
 </html>

--- a/demos/millerdisplay-bold.html
+++ b/demos/millerdisplay-bold.html
@@ -3,16 +3,16 @@
 <!--[if IE 8]>         <html class="o-useragent-ie8 o-hoverable-on"> <![endif]-->
 <!--[if gt IE 8]><!--> <html class="o-hoverable-on"> <!--<![endif]-->
 <head>
-    <meta charset="utf-8" />
-    <title>o-fonts: millerdisplay-bold demo</title>
-    <meta name="viewport" content="initial-scale=1.0, width=device-width" />
-    <script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
-    <style>body { margin: 0; }.demo-js .o--if-nojs { display: none; }</style>
-    <link rel="stylesheet" href="/bundles/css?modules=o-fonts:/demos/src/demo.scss" />
+	<meta charset="utf-8" />
+	<title>o-fonts: millerdisplay-bold demo</title>
+	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
+	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
+	<style>body { margin: 0; } .demo-js .o--if-nojs { display: none; }</style>
+	<script>(function(d) { d.className = d.className + ' demo-js'; })(document.documentElement);</script>
+	<link rel="stylesheet" href="/bundles/css?modules=o-fonts:/demos/src/demo.scss" />
 </head>
 <body class="">
-    <script>(function(d) {var b = d.getElementsByTagName('body')[0];b.className = b.className + ' demo-js';})(document);</script>
-    <div class="demo-container demo-millerdisplay-bold">
+<div class="demo-container demo-millerdisplay-bold">
 
 	<div class="demo-row">
 		<div class="demo-col">
@@ -32,7 +32,7 @@
 
 </div>
 
-    
-    <script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>
+
+<script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>
 </body>
 </html>

--- a/demos/millerdisplay-bolder.html
+++ b/demos/millerdisplay-bolder.html
@@ -3,16 +3,16 @@
 <!--[if IE 8]>         <html class="o-useragent-ie8 o-hoverable-on"> <![endif]-->
 <!--[if gt IE 8]><!--> <html class="o-hoverable-on"> <!--<![endif]-->
 <head>
-    <meta charset="utf-8" />
-    <title>o-fonts: millerdisplay-bolder demo</title>
-    <meta name="viewport" content="initial-scale=1.0, width=device-width" />
-    <script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
-    <style>body { margin: 0; }.demo-js .o--if-nojs { display: none; }</style>
-    <link rel="stylesheet" href="/bundles/css?modules=o-fonts:/demos/src/demo.scss" />
+	<meta charset="utf-8" />
+	<title>o-fonts: millerdisplay-bolder demo</title>
+	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
+	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
+	<style>body { margin: 0; } .demo-js .o--if-nojs { display: none; }</style>
+	<script>(function(d) { d.className = d.className + ' demo-js'; })(document.documentElement);</script>
+	<link rel="stylesheet" href="/bundles/css?modules=o-fonts:/demos/src/demo.scss" />
 </head>
 <body class="">
-    <script>(function(d) {var b = d.getElementsByTagName('body')[0];b.className = b.className + ' demo-js';})(document);</script>
-    <div class="demo-container demo-millerdisplay-bolder">
+<div class="demo-container demo-millerdisplay-bolder">
 
 	<div class="demo-row">
 		<div class="demo-col">
@@ -32,7 +32,7 @@
 
 </div>
 
-    
-    <script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>
+
+<script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>
 </body>
 </html>

--- a/demos/millerdisplay-normal.html
+++ b/demos/millerdisplay-normal.html
@@ -3,16 +3,16 @@
 <!--[if IE 8]>         <html class="o-useragent-ie8 o-hoverable-on"> <![endif]-->
 <!--[if gt IE 8]><!--> <html class="o-hoverable-on"> <!--<![endif]-->
 <head>
-    <meta charset="utf-8" />
-    <title>o-fonts: millerdisplay-normal demo</title>
-    <meta name="viewport" content="initial-scale=1.0, width=device-width" />
-    <script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
-    <style>body { margin: 0; }.demo-js .o--if-nojs { display: none; }</style>
-    <link rel="stylesheet" href="/bundles/css?modules=o-fonts:/demos/src/demo.scss" />
+	<meta charset="utf-8" />
+	<title>o-fonts: millerdisplay-normal demo</title>
+	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
+	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
+	<style>body { margin: 0; } .demo-js .o--if-nojs { display: none; }</style>
+	<script>(function(d) { d.className = d.className + ' demo-js'; })(document.documentElement);</script>
+	<link rel="stylesheet" href="/bundles/css?modules=o-fonts:/demos/src/demo.scss" />
 </head>
 <body class="">
-    <script>(function(d) {var b = d.getElementsByTagName('body')[0];b.className = b.className + ' demo-js';})(document);</script>
-    <div class="demo-container demo-millerdisplay-normal">
+<div class="demo-container demo-millerdisplay-normal">
 
 	<div class="demo-row">
 		<div class="demo-col">
@@ -32,7 +32,7 @@
 
 </div>
 
-    
-    <script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>
+
+<script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>
 </body>
 </html>

--- a/main.scss
+++ b/main.scss
@@ -2,6 +2,6 @@
 @import "src/scss/functions";
 @import "src/scss/mixins";
 
-@if (not $o-fonts-is-silent) {
+@if ($o-fonts-is-silent == false) {
 	@include oFontsIncludeAll();
 }

--- a/origami.json
+++ b/origami.json
@@ -75,18 +75,22 @@
         },
         {
             "path": "/demos/financierdisplay-normal.html",
+            "expanded": true,
             "description": ""
         },
         {
             "path": "/demos/financierdisplay-italic.html",
+            "expanded": true,
             "description": ""
         },
         {
             "path": "/demos/financiertext-normal.html",
+            "expanded": true,
             "description": ""
         },
         {
             "path": "/demos/financiertext-italic.html",
+            "expanded": true,
             "description": ""
         }
     ]

--- a/readme.md
+++ b/readme.md
@@ -7,21 +7,26 @@ This module provides:
 * a means of defining use cases for those fonts
 * a means of getting the `font-family` for a specific usecase
 
-It does not contain the web font files, which are contained in a separate, private repository (`o-fonts-assets`). The documentation below assumes the font assets have already been added to that.
+It does not contain the web font files, which are contained in a separate, private repository ([o-fonts-assets](http://git.svc.ft.com/projects/ORIG/repos/o-fonts-assets/)). The documentation below assumes the font assets have already been added to that.
 
 # Browser support
 This module has been verified in Internet Explorer 7+, modern desktop browsers (Chrome, Safari, Firefox, ...) and mobile browsers (Android browser, iOS safari, Chrome mobile).
 
-## Adding a new font family or variant
+## Adding families or variants
 
-Open `src/scss/_variables` in a text editor. Add the font family name (if it's an entirely new family) and the variant styles to the `$_o-fonts-families` map:
+Open `src/scss/_variables.scss` in a text editor. Add the font family name (if it's an entirely new family) and the variant styles to the `$_o-fonts-families` map:
 
 ```scss
 $_o-fonts-families: (
-	BentonSans: (lighter, normal, bold),
-	MillerDisplay: (normal, bold),
-	Clarion: (normal, bold, (normal, italic)),
-	NewFontFamily: (new style1, new style2)
+	BentonSans: (
+		font-family: 'BentonSans, sans-serif',
+		variants: (
+			(weight: lighter, style: normal),
+			(weight: normal,  style: normal),
+			(weight: bold,    style: normal)
+		)
+	),
+	// …
 );
 ```
 
@@ -48,7 +53,7 @@ And a new entry in `demos/src/demo.scss`:
 
 Demo pages are built using [origami-build-tools](https://github.com/Financial-Times/origami-build-tools), for example:
 
-    origami-build-tools demo --local --watch
+	origami-build-tools demo --local --watch
 
 This will generate demo pages in `demos/` for each demo defined in `demos/src/config.json`. Open the demo page(s) in a range of browsers to check they render as you expect.
 
@@ -65,13 +70,13 @@ Different browsers use different font formats. This is why there needs to be `.e
 Follow the standard Origami process for using this module:
 
 * Add an entry in your project's `bower.json` dependencies
-* `@import "o-fonts/main"` in your SASS
+* `@import "o-fonts/main"` in your Sass
 
 To load any given font you will need to call the `oFontsInclude()` mixin e.g.
 
 ```scss
 	@include oFontsInclude(BentonSans, bold);
-	@include oFontsInclude(Clarion, normal, italic);
+	@include oFontsInclude(MillerDisplay, $weight: normal, $style: italic);
 ```
 
 ### Specifying fonts
@@ -86,14 +91,14 @@ For example:
 }
 ```
 
-Would compile to something like this:
+Compiles to:
 
 ```css
 .myClass {
-    font-family: BentonSans, Helvetica, Arial, sans-serif;
+	font-family: BentonSans, sans-serif;
 }
 ```
 
-`oFontsGetFontFamilyWithFallbacks()` has the added benefit of warning you if the `@font-face` may not have been included.
+`oFontsGetFontFamilyWithFallbacks()` has the added benefit of warning you if the font specified doesn't exist, and as a result won't be loaded.
 
 Note that you still need to use `oFontsInclude()` to actually include the `@font-face`.

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -1,32 +1,74 @@
-@function _oFontsStyleExistsInFamilyMap($family-map, $family, $weight, $style) {
-	@each $familystyle in map-get($family-map, $family) {
-		@if (length($familystyle) == 1) {
-			$familystyle: ($familystyle normal);
-		}
-		@if (nth($familystyle, 1) == $weight and nth($familystyle, 2) == $style) {
+////
+/// @group o-fonts
+/// @link http://registry.origami.ft.com/components/o-fonts
+////
+
+/// Check if a font variant exists for a family
+///
+/// @param {String} family - one of $_o-fonts-families
+/// @param {String} weight
+/// @param {String} style
+///
+/// @access private
+///
+/// @returns {Boolean}
+///
+/// @require $_o-fonts-families
+@function _oFontsVariantExists($family, $weight, $style) {
+	$font-properties: map-get($_o-fonts-families, $family);
+	$font-variants: map-get($font-properties, variants);
+
+	@each $variant in $font-variants {
+		// Check if this weight and style variant exists for this family
+		// Known issue with LibSass 3.0.2 - https://github.com/sass/libsass/issues/741
+		@if (map-get($variant, weight) == $weight and map-get($variant, style) == $style) {
 			@return true;
 		}
 	}
 	@return false;
 }
 
-@function _oFontsDefined($family, $weight, $style) {
-	@return _oFontsStyleExistsInFamilyMap($_o-fonts-families, $family, $weight, $style);
-}
-
-@function _oFontsAlreadyIncluded($family, $weight, $style) {
-	@return _oFontsStyleExistsInFamilyMap($_o-fonts-families-included, $family, $weight, $style);
-}
-
+/// Get a font-family stack with the appropriate fallbacks
+///
+/// @param {String} family
+///
+/// @return {String} - font-stack
+///
+/// @require $_o-fonts-families
 @function oFontsGetFontFamilyWithFallbacks($family) {
-	$family-with-fallbacks: map-get($_o-font-families-with-fallbacks, $family);
-	@if ($family-with-fallbacks) {
-		@return $family-with-fallbacks;
+	@if map-has-key($_o-fonts-families, $family) {
+		$properties: map-get($_o-fonts-families, $family);
+		@return unquote(map-get($properties, font-family));
 	}
-	@warn "Unknown font-family: " + $family;
+	@warn 'Font #{$family} not found. Must be one of $_o-fonts-families.';
 	@return inherit;
 }
 
+/// Path to a font asset
+///
+/// @param {String} $asset
+///
+/// @requires $o-fonts-path
+///
+/// @return {String} - Path to the font asset, without the file extension
 @function oFontsUseAsset($asset) {
 	@return $o-fonts-path + $asset;
+}
+
+/// Machine-readable CSS font-weight.
+///
+/// @param {String} $keyword - Human-readable keyword, one of $_o-fonts-weights
+///
+/// @require {variable} $_o-fonts-weights
+///
+/// @example scss
+/// font-weight: oFontsWeight(lighter);
+///
+/// @return {Number} - CSS font-weight
+@function oFontsWeight($keyword) {
+	@if map-has-key($_o-fonts-weights, $keyword) {
+		@return map-get($_o-fonts-weights, $keyword);
+	} @else {
+		@warn 'Keyword "#{$keyword}" not found. Must be one of $_o-fonts-weights.';
+	}
 }

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -1,3 +1,13 @@
+////
+/// @group o-fonts
+/// @link http://registry.origami.ft.com/components/o-fonts
+////
+
+/// Font-face declaration sources
+///
+/// @param {String} fontName - path to the file, without the file extension
+///
+/// @require oFontsUseAsset
 @mixin oFontsSource($fontName) {
 	$fontName: to-lower-case($fontName);
 	src: url(oFontsUseAsset($fontName + '.eot')); // IE9 Compat Modes
@@ -6,50 +16,72 @@
 	url(oFontsUseAsset($fontName + '.ttf')) format('truetype'); // Safari, Android, iOS
 }
 
-@mixin oFontsInclude($family, $weight:normal, $style:normal) {
-	$weight: to-lower-case($weight);
-	$style: to-lower-case($style);
-	$font-is-defined: _oFontsDefined($family, $weight, $style);
-	$font-is-already-included: _oFontsAlreadyIncluded($family, $weight, $style);
+/// Font-face declaration for a given font family
+///
+/// @param {String} $family - one of $_o-fonts-families
+/// @param {String} $weight - one of $_o-fonts-weights
+/// @param {String} $style
+///
+/// @require {mixin} oFontsSource
+/// @require oFontsWeight
+/// @require _oFontsVariantExists
+/// @require $_o-fonts-families
+/// @require $_o-fonts-families-included
+@mixin oFontsInclude($family, $weight: normal, $style: normal) {
+	$font-exists: false;
+	// Check if the font has already been included
+	// If so, no need to output another @font-face declaration
+	$font-is-already-included: map-has-key($_o-fonts-families-included, #{$family}-#{$weight}-#{$style});
 
-	@if (not $font-is-defined) {
-		@warn "Font '" + $family + " " + $weight + " " + $style + "' not in permitted list. @font-face rule will not be output.";
-	} @else if (not $font-is-already-included) {
-		$font-suffix: $weight;
-		@if ($style != normal) {
-			@if ($weight == normal) {
-				$font-suffix:$style;
+	@if $font-is-already-included == false {
+		@if map-has-key($_o-fonts-families, $family) == false {
+			@warn 'Font #{$family} not found. Must be one of $_o-fonts-families.';
+		} @else {
+			@if (_oFontsVariantExists($family, $weight, $style)) {
+				$font-exists: true;
 			} @else {
-				$font-suffix:#{$font-suffix}-$style;
+				@warn 'Variant "weight: #{$weight}, style: #{$style}" not found for "#{$family}". @font-face rule will not be output.';
 			}
 		}
 
-		@font-face {
-			font-family: $family;
-			font-weight: $weight;
-			font-style: $style;
-			@include oFontsSource($family+-$font-suffix);
-		}
-		@if (not _oFontsStyleExistsInFamilyMap($_o-fonts-families-included, $family, $weight, $style)) {
-			$already-included-styles: map-get($_o-fonts-families-included, $family);
-			$new-included-styles: ();
-			@if ($already-included-styles) {
-				$new-included-styles: $already-included-styles;
+		@if ($font-exists) {
+			// Files are named as follows
+			// name-suffix
+			// metric-normal      (normal normal)
+			// metric-italic      (normal italic)
+			// metric-bold        (bold normal)
+			// metric-bold-italic (bold italic)
+
+			// By default, suffix is the weight
+			$font-suffix: $weight;
+
+			@if ($weight == 'normal' and $style != 'normal') {
+				$font-suffix: $style;
 			}
-			$new-included-styles: append($already-included-styles, ($weight $style));
-			$_o-fonts-families-included: map-merge($_o-fonts-families-included, (#{$family}: $new-included-styles));
+			@if ($weight != 'normal' and $style != 'normal') {
+				$font-suffix: #{$weight}-#{$style};
+			}
+
+			@font-face {
+				@include oFontsSource(#{$family}-#{$font-suffix});
+				font-family: $family;
+				font-weight: oFontsWeight($weight);
+				font-style: $style;
+			}
+
+			// Add to the list of already included families / variants
+			$_o-fonts-families-included: map-merge($_o-fonts-families-included, (#{$family}-#{$weight}-#{$style}: true)) !global;
 		}
 	}
 }
 
-@mixin oFontsIncludeAll() {
-	@each $family, $font in $_o-fonts-families {
-		@each $style in $font {
-			@if (length($style) > 1) {
-				@include oFontsInclude($family, nth($style, 1), nth($style, 2));
-			} @else {
-				@include oFontsInclude($family, nth($style, 1));
-			}
+/// Output @font-face declarations for all the font families
+///
+/// @require $_o-fonts-families
+@mixin oFontsIncludeAll {
+	@each $family, $properties in $_o-fonts-families {
+		@each $variant in map-get($properties, variants) {
+			@include oFontsInclude($family, map-get($variant, weight), map-get($variant, style));
 		}
 	}
 }

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -6,10 +6,9 @@ $o-fonts-assets-path: $o-fonts-name !default;
 $o-fonts-is-silent: true !default;
 
 // Variables used by oFontGetFontFamilyWithFallbacks(). Not to be used by modules directly.
-$_o-fonts-serif: Georgia, 'Times New Roman', serif;
 $_o-fonts-sans-serif: BentonSans, Helvetica, Arial, sans-serif;
-$_o-fonts-millerdisplay: MillerDisplay, $_o-fonts-serif;
-$_o-fonts-clarion: Clarion, $_o-fonts-serif;
+$_o-fonts-millerdisplay: MillerDisplay, Georgia, serif;
+$_o-fonts-clarion: Clarion, Georgia, serif;
 $_o-fonts-financierdisplay: FinancierDisplay, serif;
 $_o-fonts-financiertext: FinancierText, serif;
 

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -1,48 +1,90 @@
-$o-fonts-path: '//build.origami.ft.com/files/o-fonts-assets@0.2.2/' !default;
-$o-fonts-name: o-fonts;
-$o-fonts-version: null !default;
-$o-fonts-assets-path: $o-fonts-name !default;
+////
+/// @group o-fonts
+/// @link http://registry.origami.ft.com/components/o-fonts
+////
 
+/// Path to the assets
+///
+/// @type {String}
+$o-fonts-path: '//build.origami.ft.com/files/o-fonts-assets@0.2.3/' !default;
+
+/// Silent mode
+///
+/// @type {Boolean}
 $o-fonts-is-silent: true !default;
 
-// Variables used by oFontGetFontFamilyWithFallbacks(). Not to be used by modules directly.
-$_o-fonts-sans-serif: BentonSans, Helvetica, Arial, sans-serif;
-$_o-fonts-millerdisplay: MillerDisplay, Georgia, serif;
-$_o-fonts-clarion: Clarion, Georgia, serif;
-$_o-fonts-financierdisplay: FinancierDisplay, serif;
-$_o-fonts-financiertext: FinancierText, serif;
-
-$_o-font-families-with-fallbacks: (
-	BentonSans: $_o-fonts-sans-serif,
-	MillerDisplay: $_o-fonts-millerdisplay,
-	Clarion: $_o-fonts-clarion,
-	FinancierDisplay: $_o-fonts-financierdisplay,
-	FinancierText: $_o-fonts-financiertext,
-);
-
-// Map of all families, each with a list of styles for that family.
-// Only families and styles listed here will be allowed to be declared as @font-faces via the oFontsInclude mixin.
+/// Font families
+///
+/// @access private
+///
+/// @type {Map}
 $_o-fonts-families: (
-	BentonSans: (lighter, normal, bold),
-	MillerDisplay: (normal, bold),
-	Clarion: (normal, bold, (normal, italic)),
-	FinancierDisplay: (normal, (normal, italic)),
-	FinancierText: (normal, (normal, italic)),
+	BentonSans: (
+		font-family: 'BentonSans, sans-serif',
+		variants: (
+			(weight: lighter, style: normal),
+			(weight: normal,  style: normal),
+			(weight: bold,    style: normal)
+		)
+	),
+	MillerDisplay: (
+		font-family: 'MillerDisplay, Georgia, serif',
+		variants: (
+			(weight: normal, style: normal),
+			(weight: bold,   style: normal)
+		)
+	),
+	Clarion: (
+		font-family: 'Clarion, Georgia, serif',
+		variants: (
+			(weight: normal, style: normal),
+			(weight: bold,   style: normal),
+			(weight: normal, style: italic)
+		)
+	),
+	FinancierDisplay: (
+		font-family: 'FinancierDisplay, serif',
+		variants: (
+			(weight: normal, style: normal),
+			(weight: normal, style: italic)
+		)
+	),
+	FinancierText: (
+		font-family: 'FinancierText, serif',
+		variants: (
+			(weight: normal, style: normal),
+			(weight: normal, style: italic)
+		)
+	)
 );
 
-// Map of families and styles which have already been included. Exists to avoid multiple @font-face definitions
+/// Human-readable Font-weights
+///
+/// @access private
+///
+/// @type Map
+$_o-fonts-weights: (
+	'lighter':   200,
+	'normal':    400,
+	'bold':      700,
+	'bolder':    800
+) !default;
+
+/// Map of families and styles which have already been included
+/// Used to avoid declarations from being multiple times in the CSS output
+///
+/// @access private
 $_o-fonts-families-included: () !default;
 
-
-// These variables are deprecated. Modules should use the oFontsGetFontFamilyForUseCase function instead.
-$o-fonts-sans-serif: $_o-fonts-sans-serif;
+// These variables are deprecated. Modules should use the oFontsGetFontFamilyWithFallbacks function instead.
+$o-fonts-sans-serif: oFontsGetFontFamilyWithFallbacks(BentonSans);
 $o-fonts-serif: Georgia, 'Times New Roman', serif;
-$o-fonts-bentonsans-lighter: $o-fonts-sans-serif;
-$o-fonts-bentonsans-normal: $o-fonts-sans-serif;
-$o-fonts-bentonsans-bold: $o-fonts-sans-serif;
-$o-fonts-millerdisplay-normal: MillerDisplay, $o-fonts-serif;
-$o-fonts-millerdisplay-bold: MillerDisplay, $o-fonts-serif;
-$o-fonts-millerdisplay-bolder: MillerDisplay, $o-fonts-serif;
-$o-fonts-clarion-normal: Clarion, $o-fonts-serif;
-$o-fonts-clarion-bold: Clarion, $o-fonts-serif;
-$o-fonts-clarion-italic: Clarion, $o-fonts-serif;
+$o-fonts-bentonsans-lighter: oFontsGetFontFamilyWithFallbacks(BentonSans);
+$o-fonts-bentonsans-normal: oFontsGetFontFamilyWithFallbacks(BentonSans);
+$o-fonts-bentonsans-bold: oFontsGetFontFamilyWithFallbacks(BentonSans);
+$o-fonts-millerdisplay-normal: oFontsGetFontFamilyWithFallbacks(MillerDisplay);
+$o-fonts-millerdisplay-bold: oFontsGetFontFamilyWithFallbacks(MillerDisplay);
+$o-fonts-millerdisplay-bolder: oFontsGetFontFamilyWithFallbacks(MillerDisplay);
+$o-fonts-clarion-normal: oFontsGetFontFamilyWithFallbacks(Clarion);
+$o-fonts-clarion-bold: oFontsGetFontFamilyWithFallbacks(Clarion);
+$o-fonts-clarion-italic: oFontsGetFontFamilyWithFallbacks(Clarion);


### PR DESCRIPTION
- Fixes #25 and #13
- Superseeds #16

The map seems like a better way to see what is loaded in one set:

```scss
$_o-fonts-families: (
	BentonSans: (
		font-family: 'BentonSans, sans-serif',
		variants: (
			(weight: lighter, style: normal),
			(weight: normal,  style: normal),
			(weight: bold,    style: normal)
		)
	),
	MillerDisplay: (
		font-family: 'MillerDisplay, Georgia, serif',
		variants: (
			(weight: normal, style: normal),
			(weight: bold,   style: normal)
		)
	),
	Clarion: (
		font-family: 'Clarion, Georgia, serif',
		variants: (
			(weight: normal, style: normal),
			(weight: bold,   style: normal),
			(weight: normal, style: italic)
		)
	),
	FinancierDisplay: (
		font-family: 'FinancierDisplay, serif',
		variants: (
			(weight: normal, style: normal),
			(weight: normal, style: italic)
		)
	),
	FinancierText: (
		font-family: 'FinancierText, serif',
		variants: (
			(weight: normal, style: normal),
			(weight: normal, style: italic)
		)
	)
);
```

Also helped discover [a bug in LibSass](https://github.com/sass/libsass/issues/741) when trying to make the module compatible with it.