### PR TITLE
Avoid multiple fontface declarations outputs

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -4,4 +4,8 @@
 
 @if ($o-fonts-is-silent == false) {
 	@include oFontsIncludeAll();
+
+	// Output font-face declaration only once,
+	// since CSSO won't get rid of duplicate ones
+	$o-fonts-is-silent: true;
 }


### PR DESCRIPTION
Prevents duplicate @font-face declarations from getting in the CSS output. Note that CSSO doesn't de-duplicate them.