### PR TITLE
Updates for Next

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,10 +115,10 @@ $serif: oFontsGetFontFamilyWithFallbacks(FinancierDisplayWeb);
 
 Note: font files are contained in a separate, private repository ([o-fonts-assets](http://git.svc.ft.com/projects/ORIG/repos/o-fonts-assets/)).
 
-Open `src/scss/_variables.scss` in a text editor. Add the font family name (if it's an entirely new family) and the variant styles to the `$_o-fonts-families` map:
+Open `src/scss/_variables.scss` in a text editor. Add the font family name (if it's an entirely new family) and the variant styles to the `$o-fonts-families` map:
 
 ```scss
-$_o-fonts-families: (
+$o-fonts-families: (
 	BentonSans: (
 		font-family: 'BentonSans, sans-serif',
 		variants: (

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ WOFF is supported in IE 9+, Chrome, Firefox, iOS 5+, Android 4.4+.
 | Weight   | BentonSans | MillerDisplay | FinancierDisplayWeb | FinancierTextWeb | MetricWeb |
 |----------|:----------:|:-------------:|:-------------------:|:----------------:|:---------:|
 | thin     |            |               |                     |                  |     ✓     |
-| light    |      ✓     |               |                     |                  |     ✓     |
+| light    |      ✓     |               |         *i*         |                  |   ✓ *i*   |
 | regular  |      ✓     |       ✓       |        ✓ *i*        |       ✓ *i*      |   ✓ *i*   |
 | medium   |            |               |                     |                  |     ✓     |
-| semibold |            |               |                     |                  |     ✓     |
+| semibold |            |               |         *i*         |                  |     ✓     |
 | bold     |      ✓     |       ✓       |                     |                  |   ✓ *i*   |
 | black    |            |       ✓       |                     |                  |           |
 

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -5,7 +5,7 @@
 
 /// Check if a font variant exists for a family
 ///
-/// @param {String} family - one of $_o-fonts-families
+/// @param {String} family - one of $o-fonts-families
 /// @param {String} weight
 /// @param {String} style
 ///
@@ -13,7 +13,7 @@
 ///
 /// @return {Bool}
 @function _oFontsVariantExists($family, $weight, $style) {
-	$font-properties: map-get($_o-fonts-families, $family);
+	$font-properties: map-get($o-fonts-families, $family);
 	$font-variants: map-get($font-properties, variants);
 
 	@each $variant in $font-variants {
@@ -52,11 +52,11 @@
 		@warn "Clarion has been removed, use Georgia instead";
 		@return $o-fonts-serif;
 	}
-	@if map-has-key($_o-fonts-families, $family) {
-		$properties: map-get($_o-fonts-families, $family);
+	@if map-has-key($o-fonts-families, $family) {
+		$properties: map-get($o-fonts-families, $family);
 		@return unquote(map-get($properties, font-family));
 	}
-	@warn 'Font #{$family} not found. Must be one of $_o-fonts-families.';
+	@warn 'Font #{$family} not found. Must be one of $o-fonts-families.';
 	@return inherit;
 }
 

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -12,7 +12,7 @@
 
 /// Font-face declaration for a given font family
 ///
-/// @param {String} $family - one of $_o-fonts-families
+/// @param {String} $family - one of $o-fonts-families
 /// @param {String} $weight [regular] - one of $_o-fonts-weights
 /// @param {String} $style [normal]
 @mixin oFontsInclude($family, $weight: regular, $style: normal) {
@@ -28,8 +28,8 @@
 	$font-is-already-included: map-has-key($_o-fonts-families-included, #{$family}-#{$weight}-#{$style});
 
 	@if $font-is-already-included == false {
-		@if map-has-key($_o-fonts-families, $family) == false {
-			@warn 'Font #{$family} not found. Must be one of $_o-fonts-families.';
+		@if map-has-key($o-fonts-families, $family) == false {
+			@warn 'Font #{$family} not found. Must be one of $o-fonts-families.';
 		} @else {
 			@if (_oFontsVariantExists($family, $weight, $style)) {
 				$font-exists: true;
@@ -68,7 +68,7 @@
 
 /// Output @font-face declarations for all the font families
 @mixin oFontsIncludeAll {
-	@each $family, $properties in $_o-fonts-families {
+	@each $family, $properties in $o-fonts-families {
 		@each $variant in map-get($properties, variants) {
 			@include oFontsInclude($family, map-get($variant, weight), map-get($variant, style));
 		}

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -38,6 +38,7 @@ $o-fonts-families: (
 		variants: (
 			(weight: thin, style: normal),
 			(weight: light, style: normal),
+			(weight: light, style: italic),
 			(weight: regular, style: normal),
 			(weight: regular, style: italic),
 			(weight: medium, style: normal),
@@ -50,7 +51,8 @@ $o-fonts-families: (
 		font-family: 'FinancierDisplayWeb, serif',
 		variants: (
 			(weight: regular, style: normal),
-			(weight: regular, style: italic)
+			(weight: semibold, style: italic),
+			(weight: light, style: italic)
 		)
 	),
 	FinancierTextWeb: (

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -15,10 +15,8 @@ $o-fonts-is-silent: true !default;
 
 /// Font families
 ///
-/// @access private
-///
 /// @type Map
-$_o-fonts-families: (
+$o-fonts-families: (
 	BentonSans: (
 		font-family: 'BentonSans, sans-serif',
 		variants: (

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -6,7 +6,7 @@
 /// Path to the assets
 ///
 /// @type String
-$o-fonts-path: '//build.origami.ft.com/files/o-fonts-assets@1.0.0/' !default;
+$o-fonts-path: '//build.origami.ft.com/files/o-fonts-assets@1.1.0/' !default;
 
 /// Silent mode
 ///


### PR DESCRIPTION
- Makes $[_]o-fonts-families a public variable, to allow overrides
- Points to v1.1.0 of o-fonts-assets (3 new variants)
- Adds new variants to the o-fonts-families map and docs