### PR TITLE
Add Georgia as font fallback for FinancierTextWeb

### DIFF
--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -58,7 +58,7 @@ $o-fonts-families: (
 		)
 	),
 	FinancierTextWeb: (
-		font-family: 'FinancierTextWeb, serif',
+		font-family: 'FinancierTextWeb, Georgia, serif',
 		variants: (
 			(weight: regular, style: normal),
 			(weight: regular, style: italic)


### PR DESCRIPTION
For performance reasons, Next no longer pulls pulls in FinancierTextWeb: https://github.com/Financial-Times/next-sass-setup/blob/master/_approved-fonts.scss

We'd like this to fall back to Georgia before serif. Would it be appropriate to make this change across all of origami?

(Note though that Georgia is a bit bigger than whatever it is we're getting from serif, and I haven't quite worked out how we deal with size discrepancies in these cases)