### PR TITLE
Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Easily include FT web fonts in products.
 <!-- Set font families -->
 <style>
 	html {
-		font-family: BentonSans, sans-serif;
+		font-family: FinancierDisplayWeb, sans-serif;
 	}
 	h1 {
-		font-family: MillerDisplay, serif;
+		font-family: MetricWeb, serif;
 	}
 </style>
 ```
@@ -33,15 +33,15 @@ WOFF is supported in IE 9+, Chrome, Firefox, iOS 5+, Android 4.4+.
 
 ## Font families, weights and styles
 
-| Weight   | BentonSans | MillerDisplay | FinancierDisplayWeb | FinancierTextWeb | MetricWeb |
-|----------|:----------:|:-------------:|:-------------------:|:----------------:|:---------:|
-| thin     |            |               |                     |                  |     ✓     |
-| light    |      ✓     |               |         *i*         |                  |   ✓ *i*   |
-| regular  |      ✓     |       ✓       |        ✓ *i*        |       ✓ *i*      |   ✓ *i*   |
-| medium   |            |               |         *i*         |                  |     ✓     |
-| semibold |            |               |         *i*         |                  |     ✓     |
-| bold     |      ✓     |       ✓       |                     |                  |   ✓ *i*   |
-| black    |            |       ✓       |                     |                  |           |
+| Weight   | FinancierDisplayWeb | MetricWeb |
+|----------|:-------------------:|:---------:|
+| thin     |                     |     ✓     |
+| light    |         *i*         |   ✓ *i*   |
+| regular  |        ✓ *i*        |   ✓ *i*   |
+| medium   |         *i*         |     ✓     |
+| semibold |         *i*         |     ✓     |
+| bold     |                     |   ✓ *i*   |
+| black    |                     |           |
 
 *i*: italic available (if not, faux-italic will be displayed)
 
@@ -67,9 +67,9 @@ or
 @import 'o-fonts/main';
 
 // @font-face declarations for all Benton Sans weights
-@include oFontsInclude(BentonSans, light);
-@include oFontsInclude(BentonSans, regular);
-@include oFontsInclude(BentonSans, bold);
+@include oFontsInclude(FinancierDisplayWeb, light);
+@include oFontsInclude(FinancierDisplayWeb, regular);
+@include oFontsInclude(FinancierDisplayWeb, bold);
 
 // @font-face declarations for Metric regular / italic
 @include oFontsInclude(MetricWeb, $weight: regular, $style: italic);
@@ -81,7 +81,7 @@ or
 
 ```scss
 .my-class {
-	font-family: oFontsGetFontFamilyWithFallbacks(BentonSans);
+	font-family: oFontsGetFontFamilyWithFallbacks(FinancierDisplayWeb);
 }
 ```
 
@@ -89,7 +89,7 @@ Compiles to:
 
 ```css
 .my-class {
-	font-family: BentonSans, sans-serif;
+	font-family: FinancierDisplayWeb, sans-serif;
 }
 ```
 
@@ -156,7 +156,5 @@ And a new entry in `demos/src/demo.scss`:
 ----
 
 ## License
-
-Copyright (c) 2016 Financial Times Ltd. All rights reserved.
 
 This software is published under the [MIT licence](http://opensource.org/licenses/MIT).

--- a/origami.json
+++ b/origami.json
@@ -1,5 +1,5 @@
 {
-	"description": "Web font loader",
+	"description": "Webfont loader for the FT's fonts.",
 	"origamiType": "module",
 	"origamiCategory": "primitives",
 	"origamiVersion": 1,
@@ -14,28 +14,13 @@
 	},
 	"demos": [
 		{
-			"name": "bentonsans",
-			"data": {
-				"font": "bentonsans"
-			},
-			"expanded": true,
-			"description": ""
-		},
-		{
-			"name": "millerdisplay",
-			"data": {
-				"font": "millerdisplay"
-			},
-			"expanded": true,
-			"description": ""
-		},
-		{
 			"name": "metricweb",
 			"data": {
 				"font": "metricweb"
 			},
 			"expanded": true,
-			"description": ""
+			"description": "Metric is used for utility text, eg categories, tags and navigation",
+			"display_html": false
 		},
 		{
 			"name": "financierdisplayweb",
@@ -43,15 +28,8 @@
 				"font": "financierdisplayweb"
 			},
 			"expanded": true,
-			"description": ""
-		},
-		{
-			"name": "financiertextweb",
-			"data": {
-				"font": "financiertextweb"
-			},
-			"expanded": true,
-			"description": ""
+			"description": "Financier Display is used for headlines and editorial content at large sizes.",
+			"display_html": false
 		}
 	]
 }

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -52,6 +52,18 @@
 		@warn "Clarion has been removed, use Georgia instead";
 		@return $o-fonts-serif;
 	}
+
+	@if $family == 'Benton' {
+		@warn "Benton is deprecated. It will be removed in the next major version (v3). Please use Metric instead.";
+	}
+	@if $family == 'Miller' {
+		@warn "Miller is deprecated. It will be removed in the next major version (v3). Please use Financier instead.";
+	}
+	@if $family == 'FinancierTextWeb' {
+		@warn "FinancierTextWeb is deprecated. It will be removed in the next major version (v3). Please use Georgia instead";
+	}
+
+
 	@if map-has-key($o-fonts-families, $family) {
 		$properties: map-get($o-fonts-families, $family);
 		@return unquote(map-get($properties, font-family));

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -19,6 +19,17 @@
 	@if $family == 'Clarion' {
 		@warn "Clarion has been removed, no font will be included. Use Georgia instead";
 	}
+
+	@if $family == 'Benton' {
+		@warn "Benton is deprecated. It will be removed in the next major version (v3). Please use Metric instead.";
+	}
+	@if $family == 'Miller' {
+		@warn "Miller is deprecated. It will be removed in the next major version (v3). Please use Financier instead.";
+	}
+	@if $family == 'FinancierTextWeb' {
+		@warn "FinancierTextWeb is deprecated. It will be removed in the next major version (v3). Please use Georgia instead";
+	}
+
 	@if $weight == normal {
 		$weight: regular;
 	}


### PR DESCRIPTION
Deprecate Miller, Benton and Financier Text.

- Remove demos
- Change readme to use Financier display
- Add better descriptions to origami.json for Financier and Metric