### PR TITLE
Remove iefix and format

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -7,7 +7,7 @@
 ///
 /// @param {String} fontName - path to the file, without the file extension
 @mixin oFontsSource($fontName) {
-	src: url(oFontsUseAsset($fontName + '.woff?#iefix')) format('woff');
+	src: url(oFontsUseAsset($fontName + '.woff'));
 }
 
 /// Font-face declaration for a given font family


### PR DESCRIPTION
(***giant caveat →***) i think (***← giant caveat***) `format` is unnecessary because there's only one `src`.

the `iefix` is breaking these fonts working offline in the webapp because the `?` isn't the same as in the manifest. we _could_ add a `?` to the URLs in the manifest, but we don't wanna.