### PR TITLE
Add the ability to register custom fonts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ It is also possible to register custom fonts with `o-fonts` using the mixin `oFo
 
 In this example we register a custom font "MyFont" with sans fallback `MyFont, sans`. We configure this font to allow two variants (a normal style of either bold or regular weight). In the mixin content we include the `@font-face` declaration to load these fonts from our own source.
 ```scss
-@include oFontsIncludeCustomFont('MyFont, sans', (
+@include oFontsDefineCustomFont('MyFont, sans', (
     (weight: regular, style: normal),
     (weight: bold, style: normal)
 )) {

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ WOFF is supported in IE 9+, Chrome, Firefox, iOS 5+, Android 4.4+.
 
 ## Advanced usage<a name="advanced"></a>
 
-### Loading all the web fonts
+### Loading all Origami provided web fonts
 
 ```scss
 $o-fonts-is-silent: false;
@@ -61,7 +61,7 @@ or
 @include oFontsIncludeAll();
 ```
 
-### Loading specific web fonts
+### Loading specific Origami provided web fonts
 
 ```scss
 @import 'o-fonts/main';
@@ -91,6 +91,46 @@ Compiles to:
 .my-class {
 	font-family: FinancierDisplayWeb, sans-serif;
 }
+```
+
+`oFontsGetFontFamilyWithoutFallbacks` performs the inverse:
+
+```scss
+	$without-fallbacks: oFontsGetFontFamilyWithoutFallbacks('FinancierDisplayWeb, sans-serif'); // FinancierDisplayWeb
+```
+
+### Checking a weight or style is allowed
+
+To check if a font supports a weight/style use `oFontsVariantExists`.
+
+```scss
+$allowed: oFontsVariantExists('MetricWeb', 'bold', 'normal'); // true
+$allowed: oFontsVariantExists('MetricWeb', 'black', 'italic'); // false
+```
+
+### Using custom font families
+
+It is also possible to register custom fonts with `o-fonts` using the mixin `oFontsGetFontFamilyWithoutFallbacks`.
+
+In this example we register a custom font "MyFont" with sans fallback `MyFont, sans`. We configure this font to allow two variants (a normal style of either bold or regular weight). In the mixin content we include the `@font-face` declaration to load these fonts from our own source.
+```scss
+@include oFontsIncludeCustomFont('MyFont, sans', (
+    (weight: regular, style: normal),
+    (weight: bold, style: normal)
+)) {
+    @font-face {
+        src: url('MyFont-Thin.woff');
+        font-family: MyFont;
+        font-weight: 100;
+        font-style: normal;
+    }
+    @font-face{
+        src: url('MyFont-Bold.woff');
+        font-family: MyFont;
+        font-weight: 700;
+        font-style: normal;
+    }
+};
 ```
 
 ====

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ WOFF is supported in IE 9+, Chrome, Firefox, iOS 5+, Android 4.4+.
 
 ## Advanced usage<a name="advanced"></a>
 
-### Loading all Origami provided web fonts
+### Loading all web fonts provided by Origami
 
 ```scss
 $o-fonts-is-silent: false;
@@ -61,7 +61,7 @@ or
 @include oFontsIncludeAll();
 ```
 
-### Loading specific Origami provided web fonts
+### Loading specific web fonts provided by Origami
 
 ```scss
 @import 'o-fonts/main';

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ $allowed: oFontsVariantExists('MetricWeb', 'black', 'italic'); // false
 
 ### Using custom font families
 
-It is also possible to register custom fonts with `o-fonts` using the mixin `oFontsGetFontFamilyWithoutFallbacks`.
+It is also possible to register custom fonts with `o-fonts` using the mixin `oFontsDefineCustomFont`.
 
 In this example we register a custom font "MyFont" with sans fallback `MyFont, sans`. We configure this font to allow two variants (a normal style of either bold or regular weight). In the mixin content we include the `@font-face` declaration to load these fonts from our own source.
 ```scss

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -5,9 +5,9 @@
 /// @param {String} $weight [regular] - The font weight.
 /// @param {String} $style [normal] - The font style.
 /// @return {Bool}
-@function oFontsVariantExists($family, $weight: 'regular', $style: 'normal') {
-	$weight: if($weight, $weight, 'regular');
-	$style: if($style, $style, 'normal');
+@function oFontsVariantExists($family, $weight, $style) {
+	$weight: if($weight, $weight, 'regular'); // Handles a falsy `$weight` value.
+	$style: if($style, $style, 'normal'); // Handles a falsy `$style` value.
 	$font-properties: map-get($o-fonts-families, $family);
 	$font-variants: map-get($font-properties, variants);
 

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -1,18 +1,13 @@
-////
-/// @group o-fonts
-/// @link http://registry.origami.ft.com/components/o-fonts
-////
-
 /// Check if a font variant exists for a family
 ///
-/// @param {String} family - one of $o-fonts-families
-/// @param {String} weight
-/// @param {String} style
-///
-/// @access private
-///
+/// @access public
+/// @param {String} $family - one of $o-fonts-families
+/// @param {String} $weight [regular] - The font weight.
+/// @param {String} $style [normal] - The font style.
 /// @return {Bool}
-@function _oFontsVariantExists($family, $weight, $style) {
+@function oFontsVariantExists($family, $weight: 'regular', $style: 'normal') {
+	$weight: if($weight, $weight, 'regular');
+	$style: if($style, $style, 'normal');
 	$font-properties: map-get($o-fonts-families, $family);
 	$font-variants: map-get($font-properties, variants);
 
@@ -59,6 +54,22 @@
 	}
 	@warn 'Font #{$family} not found. Must be one of $o-fonts-families.';
 	@return inherit;
+}
+
+/// Removes a fonts fallbacks.
+/// @example
+///     $family: oFontsGetFontFamilyWithoutFallbacks('FinancierDisplayWeb, sans'); //FinancierDisplayWeb
+/// @param {String|List} $family - Font family potentially with fallbacks.
+/// @returns {String} Font family without fallbacks.
+@function oFontsGetFontFamilyWithoutFallbacks($family) {
+	@if type-of($family) == 'list' {
+		@return nth($family, 1);
+	}
+	$index: str-index($family, ',');
+	@if $index {
+		$family: str-slice($family, 0, $index - 1);
+	}
+	@return if($family, $family, '');
 }
 
 /// Path to a font asset

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -5,8 +5,7 @@
 	src: url(oFontsUseAsset($fontName + '.woff'));
 }
 
-
-/// Output a Font-face declaration for a given Origami provided font family.
+/// Output a Font-face declaration for a given font family which is provided by Origami.
 ///
 /// @param {String} $family - one of $o-fonts-families
 /// @param {String} $weight [regular] - one of $_o-fonts-weights
@@ -74,7 +73,7 @@
 	}
 }
 
-/// Output all Font-face declarations for Origami provided fonts.
+/// Output all Font-face declarations which are provided by Origami.
 @mixin oFontsIncludeAll {
 	@each $family, $properties in $o-fonts-families {
 		@if not map-get($properties, 'custom') {

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -1,8 +1,3 @@
-////
-/// @group o-fonts
-/// @link http://registry.origami.ft.com/components/o-fonts
-////
-
 /// Font-face declaration sources
 ///
 /// @param {String} fontName - path to the file, without the file extension
@@ -10,7 +5,8 @@
 	src: url(oFontsUseAsset($fontName + '.woff'));
 }
 
-/// Font-face declaration for a given font family
+
+/// Output a Font-face declaration for a given Origami provided font family.
 ///
 /// @param {String} $family - one of $o-fonts-families
 /// @param {String} $weight [regular] - one of $_o-fonts-weights
@@ -33,7 +29,7 @@
 		@if map-has-key($o-fonts-families, $family) == false {
 			@warn 'Font #{$family} not found. Must be one of $o-fonts-families.';
 		} @else {
-			@if (_oFontsVariantExists($family, $weight, $style)) {
+			@if (oFontsVariantExists($family, $weight, $style)) {
 				$font-exists: true;
 			} @else {
 				@warn 'Variant "weight: #{$weight}, style: #{$style}" not found for "#{$family}". @font-face rule will not be output.';
@@ -70,11 +66,56 @@
 	}
 }
 
-/// Output @font-face declarations for all the font families
+/// Output all Font-face declarations for Origami provided fonts.
 @mixin oFontsIncludeAll {
 	@each $family, $properties in $o-fonts-families {
 		@each $variant in map-get($properties, variants) {
 			@include oFontsInclude($family, map-get($variant, weight), map-get($variant, style));
 		}
 	}
+}
+
+/// Output custom Font-face declarations and register the family and variants with o-fonts.
+///
+/// @example This example shows registering a custom font "MyFont" with "sans" fallback. The font allows regular or bold variants.
+/// 	@include oFontsIncludeCustomFont('MyFont, sans', (
+/// 		(weight: regular, style: normal),
+/// 		(weight: bold, style: normal)
+/// 	)) {
+/// 		@font-face {
+/// 			src: url('MyFont-Thin.woff');
+/// 			font-family: MyFont;
+/// 			font-weight: 100;
+/// 			font-style: normal;
+/// 		}
+///
+/// 		@font-face{
+/// 			src: url('MyFont-Bold.woff');
+/// 			font-family: MyFont;
+/// 			font-weight: 700;
+/// 			font-style: normal;
+/// 		}
+/// 	};
+///
+/// @param {String} $font-family The custom font family with fallback e.g. 'ComicSans, sans'
+/// @param {Map} $variants The variants (weight and style combinations) which are allowed in a nested map e.g. ((weight: bold, style: normal), (weight: regular, style: normal))
+/// @content If the font family is not a system font, output the font-face for the custom font in the mixin content.
+@mixin oFontsIncludeCustomFont($font-family, $variants) {
+	// Validate variants.
+	@each $variant in $variants {
+		$weight: map-get($variant, 'weight');
+		$style: map-get($variant, 'style');
+		@if type-of($weight) != 'string' and map-has-key($_o-fonts-weights, $weight) {
+			@error 'Could not include custom font "#{$font-family}". All variants must specify a weight, one of "#{$_o-fonts-weights}".';
+		}
+		@if type-of($style) != 'string' {
+			@error 'Could not include custom font "#{$font-family}". All variants must specify a style, e.g. "normal", "italic".';
+		}
+	}
+	$font-key: oFontsGetFontFamilyWithoutFallbacks($font-family);
+	$o-fonts-families: map-merge(($font-key: (
+		'font-family': $font-family,
+		'variants': $variants
+	)), $o-fonts-families) !global;
+	@content; // Output a custom Font-face declaration.
 }

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -88,7 +88,7 @@
 /// Output custom Font-face declarations and register the family and variants with o-fonts.
 ///
 /// @example This example shows registering a custom font "MyFont" with "sans" fallback. The font allows regular or bold variants.
-/// 	@include oFontsIncludeCustomFont('MyFont, sans', (
+/// 	@include oFontsDefineCustomFont('MyFont, sans', (
 /// 		(weight: regular, style: normal),
 /// 		(weight: bold, style: normal)
 /// 	)) {
@@ -110,7 +110,7 @@
 /// @param {String} $font-family The custom font family with fallback e.g. 'ComicSans, sans'
 /// @param {Map} $variants The variants (weight and style combinations) which are allowed in a nested map e.g. ((weight: bold, style: normal), (weight: regular, style: normal))
 /// @content If the font family is not a system font, output the font-face for the custom font in the mixin content.
-@mixin oFontsIncludeCustomFont($font-family, $variants) {
+@mixin oFontsDefineCustomFont($font-family, $variants) {
 	// Validate variants.
 	@each $variant in $variants {
 		$weight: map-get($variant, 'weight');

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -20,6 +20,14 @@
 		$weight: regular;
 	}
 
+	// Check the font is an Origami font, not a custom font.
+	@if map-has-key($o-fonts-families, $family) {
+		$font-family-config: map-get($o-fonts-families, $family);
+		@if map-get($font-family-config, 'custom') {
+			@error 'Can not include a custom font "#{$family}". Include your custom font manually.';
+		}
+	}
+
 	$font-exists: false;
 	// Check if the font has already been included
 	// If so, no need to output another @font-face declaration
@@ -69,8 +77,10 @@
 /// Output all Font-face declarations for Origami provided fonts.
 @mixin oFontsIncludeAll {
 	@each $family, $properties in $o-fonts-families {
-		@each $variant in map-get($properties, variants) {
-			@include oFontsInclude($family, map-get($variant, weight), map-get($variant, style));
+		@if not map-get($properties, 'custom') {
+			@each $variant in map-get($properties, variants) {
+				@include oFontsInclude($family, map-get($variant, weight), map-get($variant, style));
+			}
 		}
 	}
 }
@@ -115,7 +125,8 @@
 	$font-key: oFontsGetFontFamilyWithoutFallbacks($font-family);
 	$o-fonts-families: map-merge(($font-key: (
 		'font-family': $font-family,
-		'variants': $variants
+		'variants': $variants,
+		'custom': true
 	)), $o-fonts-families) !global;
 	@content; // Output a custom Font-face declaration.
 }

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -1,8 +1,3 @@
-////
-/// @group o-fonts
-/// @link http://registry.origami.ft.com/components/o-fonts
-////
-
 /// Path to the assets
 ///
 /// @type String

--- a/test/scss/_functions.test.scss
+++ b/test/scss/_functions.test.scss
@@ -1,0 +1,49 @@
+@include test-module('oFontsVariantExists') {
+	@include test('Returns false when the variant does not exist.') {
+        @include assert-equal(
+            oFontsVariantExists('MetricWeb', 'black', 'italic'),
+            false
+        );
+	}
+	@include test('Returns true when the variant does exist.') {
+        @include assert-equal(
+            oFontsVariantExists('MetricWeb', 'bold', 'italic'),
+            true
+        );
+	}
+	@include test('Uses the default weight/style when given a falsy value.') {
+        // Checks for the font 'MetricWeb' with a default weight/style, i.e. normal/regular.
+        @include assert-equal(
+            oFontsVariantExists('MetricWeb', false, false),
+            true
+        );
+	}
+}
+
+@include test-module('oFontsGetFontFamilyWithoutFallbacks') {
+	@include test('Does nothing to a font family which has no fallback') {
+        @include assert-equal(
+            oFontsGetFontFamilyWithoutFallbacks('MetricWeb'),
+            'MetricWeb'
+        );
+    }
+	@include test('Removes fallback fonts from a font family with one fallback') {
+        @include assert-equal(
+            oFontsGetFontFamilyWithoutFallbacks('MetricWeb, sans'),
+            'MetricWeb'
+        );
+	}
+	@include test('Removes fallback fonts from a font family with two fallbacks') {
+        @include assert-equal(
+            oFontsGetFontFamilyWithoutFallbacks('MetricWeb, SomeOtherFont, sans'),
+            'MetricWeb'
+        );
+	}
+	@include test('Removes fallback fonts from a font family defined as a list rather than string') {
+        $test-list-family: MetricWeb, SomeOtherFont, sans;
+        @include assert-equal(
+            oFontsGetFontFamilyWithoutFallbacks($test-list-family),
+            'MetricWeb'
+        );
+	}
+}

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -1,0 +1,27 @@
+@include test-module('oFontsIncludeCustomFont') {
+	@include test('Outputs the custom font face and updates the "$o-fonts-families" map.') {
+
+        @include assert {
+            // Include a custom font with regular and bold variants.
+            @include output {
+                @include oFontsIncludeCustomFont('MyFont, sans', (
+                    (weight: regular, style: normal),
+                    (weight: bold, style: normal)
+                )) {
+                    // True wraps this test in a class. We can't do that with font-face.
+                    // Instead test mixin content is output with arbitrary CSS.
+                    content: 'Just a test. Font face here.';
+                };
+            }
+            @include expect {
+                content: 'Just a test. Font face here.';
+            }
+        }
+
+        // The font faces are output.
+        @include assert-equal(
+            $o-fonts-families,
+            ("MyFont": ("font-family": "MyFont, sans", "variants": ((weight: regular, style: normal), (weight: bold, style: normal))), MetricWeb: (font-family: "MetricWeb, sans-serif", variants: ((weight: thin, style: normal), (weight: light, style: normal), (weight: light, style: italic), (weight: regular, style: normal), (weight: regular, style: italic), (weight: medium, style: normal), (weight: semibold, style: normal), (weight: bold, style: normal), (weight: bold, style: italic))), FinancierDisplayWeb: (font-family: "FinancierDisplayWeb, serif", variants: ((weight: light, style: italic), (weight: regular, style: normal), (weight: medium, style: italic), (weight: semibold, style: italic), (weight: bold, style: normal))))
+        );
+	}
+}

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -1,10 +1,10 @@
-@include test-module('oFontsIncludeCustomFont') {
+@include test-module('oFontsDefineCustomFont') {
 	@include test('Outputs the custom font face and updates the "$o-fonts-families" map.') {
 
         @include assert {
             // Include a custom font with regular and bold variants.
             @include output {
-                @include oFontsIncludeCustomFont('MyFont, sans', (
+                @include oFontsDefineCustomFont('MyFont, sans', (
                     (weight: regular, style: normal),
                     (weight: bold, style: normal)
                 )) {

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -21,7 +21,7 @@
         // The font faces are output.
         @include assert-equal(
             $o-fonts-families,
-            ("MyFont": ("font-family": "MyFont, sans", "variants": ((weight: regular, style: normal), (weight: bold, style: normal))), MetricWeb: (font-family: "MetricWeb, sans-serif", variants: ((weight: thin, style: normal), (weight: light, style: normal), (weight: light, style: italic), (weight: regular, style: normal), (weight: regular, style: italic), (weight: medium, style: normal), (weight: semibold, style: normal), (weight: bold, style: normal), (weight: bold, style: italic))), FinancierDisplayWeb: (font-family: "FinancierDisplayWeb, serif", variants: ((weight: light, style: italic), (weight: regular, style: normal), (weight: medium, style: italic), (weight: semibold, style: italic), (weight: bold, style: normal))))
+            ("MyFont": ("font-family": "MyFont, sans", "variants": ((weight: regular, style: normal), (weight: bold, style: normal)), "custom": true), MetricWeb: (font-family: "MetricWeb, sans-serif", variants: ((weight: thin, style: normal), (weight: light, style: normal), (weight: light, style: italic), (weight: regular, style: normal), (weight: regular, style: italic), (weight: medium, style: normal), (weight: semibold, style: normal), (weight: bold, style: normal), (weight: bold, style: italic))), FinancierDisplayWeb: (font-family: "FinancierDisplayWeb, serif", variants: ((weight: light, style: italic), (weight: regular, style: normal), (weight: medium, style: italic), (weight: semibold, style: italic), (weight: bold, style: normal))))
         );
 	}
 }

--- a/test/scss/index.test.scss
+++ b/test/scss/index.test.scss
@@ -1,0 +1,6 @@
+@import 'true';
+
+@import '../../main';
+
+@import 'functions.test';
+@import 'mixins.test';


### PR DESCRIPTION
Context here: https://github.com/Financial-Times/o-typography/pull/163

**New Functions:**
- oFontsGetFontFamilyWithoutFallbacks
```scss
$without-fallbacks: oFontsGetFontFamilyWithoutFallbacks('FinancierDisplayWeb, sans-serif'); // FinancierDisplayWeb
```
- oFontsVariantExists -- _previously private_
```scss
$allowed: oFontsVariantExists('MetricWeb', 'bold', 'normal'); // true
$allowed: oFontsVariantExists('MetricWeb', 'black', 'italic'); // false
```

**New Mixins:**
- ~oFontsIncludeCustomFont~ oFontsDefineCustomFont
```scss
@include oFontsDefineCustomFont('MyFont, sans', (
    (weight: regular, style: normal),
    (weight: bold, style: normal)
)) {
    @font-face {
        src: url(MyFont-Thin.woff);
        font-family: MyFont;
        font-weight: 100;
        font-style: normal
    }
    @font-face{
        src: url(MyFont-Bold.woff);
        font-family: MyFont;
        font-weight: 700;
        font-style: normal
    }
};
```