### PR TITLE
Do not trust user if font variant is unregistered.

### DIFF
--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -1,5 +1,4 @@
 /// Check if a font variant exists for a family.
-/// If the font has not been defined returns true by default.
 ///
 /// @access public
 /// @param {String} $family - one of $o-fonts-families
@@ -11,10 +10,10 @@
 	$weight: if($weight, $weight, 'regular'); // Handles a falsy `$weight` value.
 	$style: if($style, $style, 'normal'); // Handles a falsy `$style` value.
 	$font-properties: map-get($o-fonts-families, $family);
-	// Could not find supported font variants.
-	// Trust the user, assume a system font or that the variant exists for their font.
+	// Font is not registered.
 	@if type-of($font-properties) != 'map' {
-		@return true;
+		@warn 'Could not find any supported font variants for "#{$family}". See `oFontsDefineCustomFont` to register a font and its supported weights/styles.';
+		@return false;
 	}
 	$font-variants: map-get($font-properties, variants);
 

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -1,14 +1,21 @@
-/// Check if a font variant exists for a family
+/// Check if a font variant exists for a family.
+/// If the font has not been defined returns true by default.
 ///
 /// @access public
 /// @param {String} $family - one of $o-fonts-families
 /// @param {String} $weight [regular] - The font weight.
 /// @param {String} $style [normal] - The font style.
 /// @return {Bool}
+/// @see oFontsDefineCustomFont To register a custom font's avalible variants.
 @function oFontsVariantExists($family, $weight, $style) {
 	$weight: if($weight, $weight, 'regular'); // Handles a falsy `$weight` value.
 	$style: if($style, $style, 'normal'); // Handles a falsy `$style` value.
 	$font-properties: map-get($o-fonts-families, $family);
+	// Could not find supported font variants.
+	// Trust the user, assume a system font or that the variant exists for their font.
+	@if type-of($font-properties) != 'map' {
+		@return true;
+	}
 	$font-variants: map-get($font-properties, variants);
 
 	@each $variant in $font-variants {

--- a/test/scss/_functions.test.scss
+++ b/test/scss/_functions.test.scss
@@ -18,10 +18,10 @@
             true
         );
 	}
-	@include test('Returns true when the font has not been defined') {
+	@include test('Returns false when the font has not been defined') {
         @include assert-equal(
-            oFontsVariantExists('UnknownFontName', 'bold', 'italic'),
-            true
+            oFontsVariantExists('UnknownFontName', 'regular', 'normal'),
+            false
         );
 	}
 }

--- a/test/scss/_functions.test.scss
+++ b/test/scss/_functions.test.scss
@@ -18,6 +18,12 @@
             true
         );
 	}
+	@include test('Returns true when the font has not been defined') {
+        @include assert-equal(
+            oFontsVariantExists('UnknownFontName', 'bold', 'italic'),
+            true
+        );
+	}
 }
 
 @include test-module('oFontsGetFontFamilyWithoutFallbacks') {


### PR DESCRIPTION
Checking for `Georgia` using `oFontsVariantExists ` throws an error in `o-typography`.

a. I would either need to register `Georgia` within `o-typography`:
```
@include oFontsDefineCustomFont('Georgia, serif', (
	(weight: regular, style: normal),
	(weight: regular, style: italic),
	(weight: bold, style: normal),
	(weight: bold, style: italic)
));
```

b. Or (as this PR does) make `o-fonts` more relaxed.

**I'm undecided which route to go still. Feedback welcome.**