### PR TITLE
Brand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
+.DS_Store
+.env
+/.sass-cache/
+/bower_components/
+/node_modules/
+/build/
 .idea/
-.sass-cache/
-build/
-demos/local/
+/demos/local
+/coverage

--- a/README.md
+++ b/README.md
@@ -1,65 +1,56 @@
+o-fonts [![Circle CI](https://circleci.com/gh/Financial-Times/o-fonts/tree/master.svg?style=svg)](https://circleci.com/gh/Financial-Times/o-fonts/tree/master)
+=================
 
-# o-fonts [![Build Status](https://circleci.com/gh/Financial-Times/o-fonts.png?style=shield&circle-token=c29a1b0246bd3bbad4da8e024954af6c8dc04dca)](https://circleci.com/gh/Financial-Times/o-fonts) [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](#licence)
+_Use `o-fonts` to include Origami provided fonts, or register supported custom fonts._
 
-Easily include FT web fonts in products.
+- [Fonts Available](#fonts-available)
+- [Fonts Included By Default](#fonts-included-by-default)
+- [Sass](#sass)
+- [Contributing](#contributing)
+- [Migration guide](#migration-guide)
+- [Contact](#contact)
+- [Licence](#licence)
 
-## Quick start
 
-```html
-<!-- Load web fonts with @font-face declarations  -->
-<link rel="stylesheet" href="//www.ft.com/__origami/service/build/v2/bundles/css?modules=o-fonts@^3" />
+## Fonts Available
 
-<!-- Set font families -->
-<style>
-	html {
-		font-family: FinancierDisplayWeb, sans-serif;
-	}
-	h1 {
-		font-family: MetricWeb, serif;
-	}
-</style>
-```
-
-[Looking for more advanced usage options (Sass…)?](#advanced)
-
-----
-
-## Browser support
-
-`o-fonts` loads web fonts in the [WOFF format](http://en.wikipedia.org/wiki/Web_Open_Font_Format).
-
-WOFF is supported in IE 9+, Chrome, Firefox, iOS 5+, Android 4.4+.
-[View full support table on caniuse.com](http://caniuse.com/#feat=woff).
-
-## Font families, weights and styles
+Any of the below fonts may be included with `o-fonts` using [SASS](#sass). But the [fonts included by default](#fonts-included-by-default) vary per brand.
 
 | Weight   | FinancierDisplayWeb | MetricWeb |
 |----------|:-------------------:|:---------:|
-| thin     |                     |     ✓     |
-| light    |         *i*         |   ✓ *i*   |
-| regular  |        ✓ *i*        |   ✓ *i*   |
-| medium   |         *i*         |     ✓     |
-| semibold |         *i*         |     ✓     |
-| bold     |                     |   ✓ *i*   |
+| thin     |                     |    ✓      |
+| light    |           i         |    ✓ i    |
+| regular  |         ✓ i         |    ✓ i    |
+| medium   |           i         |    ✓      |
+| semibold |           i         |    ✓      |
+| bold     |                     |    ✓ i    |
 | black    |                     |           |
 
-*i*: italic available (if not, faux-italic will be displayed)
+✓: normal style available
+i: italic style available (if not, faux-italic will be displayed)
 
-## Advanced usage<a name="advanced"></a>
+## Fonts Included By Default
 
-### Loading all web fonts provided by Origami
+Font faces included by default, if using the Origami Build Service or [including all fonts with SASS](#sass), depends on your products chosen brand:
 
-```scss
-$o-fonts-is-silent: false;
-@import 'o-fonts/main';
-```
+| Brand       | Fonts included by default (all weights and styles) |
+|-------------|:--------------------------------------------------:|
+| master      | FinancierDisplayWeb, MetricWeb                     |
+| internal    | MetricWeb                                          |
+| whitelabel  | _(none)_                                           |
 
-or
+## Sass
+
+### Include All Default Fonts
+
+To include [all default fonts for your brand](#fonts-included-by-default), call `oFontsIncludeAll`.
 
 ```scss
 @import 'o-fonts/main';
 @include oFontsIncludeAll();
 ```
+
+_If you want to include a font which is provided by Origami but not included by for your brand default, [specifically load the font](#loading-specific-web-fonts–provided-by-origami) separately._
 
 ### Loading specific web fonts provided by Origami
 
@@ -75,42 +66,9 @@ or
 @include oFontsInclude(MetricWeb, $weight: regular, $style: italic);
 ```
 
-### Specifying font families
+### Use a custom font family
 
-`oFontsGetFontFamilyWithFallbacks()` is a function that returns the correct `font-family` with web safe fallbacks.
-
-```scss
-.my-class {
-	font-family: oFontsGetFontFamilyWithFallbacks(FinancierDisplayWeb);
-}
-```
-
-Compiles to:
-
-```css
-.my-class {
-	font-family: FinancierDisplayWeb, sans-serif;
-}
-```
-
-`oFontsGetFontFamilyWithoutFallbacks` performs the inverse:
-
-```scss
-	$without-fallbacks: oFontsGetFontFamilyWithoutFallbacks('FinancierDisplayWeb, sans-serif'); // FinancierDisplayWeb
-```
-
-### Checking a weight or style is allowed
-
-To check if a font supports a weight/style use `oFontsVariantExists`.
-
-```scss
-$allowed: oFontsVariantExists('MetricWeb', 'bold', 'normal'); // true
-$allowed: oFontsVariantExists('MetricWeb', 'black', 'italic'); // false
-```
-
-### Using custom font families
-
-It is also possible to register custom fonts with `o-fonts` using the mixin `oFontsDefineCustomFont`.
+To register a custom font and supported variants, use the mixin `oFontsDefineCustomFont`.
 
 In this example we register a custom font "MyFont" with sans fallback `MyFont, sans`. We configure this font to allow two variants (a normal style of either bold or regular weight). In the mixin content we include the `@font-face` declaration to load these fonts from our own source.
 ```scss
@@ -133,36 +91,38 @@ In this example we register a custom font "MyFont" with sans fallback `MyFont, s
 };
 ```
 
-====
+### Specifying font families
 
-Product tip: store the family in a variable for brevity.
+To get a `font-family` with web safe fallbacks for a font, use the `oFontsGetFontFamilyWithFallbacks` function.
 
 ```scss
-// _my-variables.scss
-$serif: oFontsGetFontFamilyWithFallbacks(FinancierDisplayWeb);
-
-// foo.scss
-@import 'my-variables';
-.foo {
-	font-family: $serif;
-}
-
-// bar.scss
-@import 'my-variables';
-.bar {
-	font-family: $serif;
+.my-class {
+	font-family: oFontsGetFontFamilyWithFallbacks(FinancierDisplayWeb); // FinancierDisplayWeb, sans-serif
 }
 ```
 
-`oFontsGetFontFamilyWithFallbacks()` has the added benefit of warning you if the family specified doesn't exist in the list of supported families (which as a result wouldn't show the text as intended).
+To get a font without the fallbacks, use `oFontsGetFontFamilyWithoutFallbacks`:
 
-----
+```scss
+	$without-fallbacks: oFontsGetFontFamilyWithoutFallbacks('FinancierDisplayWeb, sans-serif'); // FinancierDisplayWeb
+```
 
-## Contribute (*adding new variants*)
+### Checking a weight or style is allowed
+
+To check if a font supports a weight/style use `oFontsVariantExists`.
+
+```scss
+$allowed: oFontsVariantExists('MetricWeb', 'bold', 'normal'); // true
+$allowed: oFontsVariantExists('MetricWeb', 'black', 'italic'); // false
+```
+
+## Contributing
+
+### Adding new font variants
 
 Note: font files are contained in a separate, private repository ([o-fonts-assets](https://github.com/Financial-Times/o-fonts-assets)).
 
-Open `src/scss/_variables.scss` in a text editor. Add the font family name (if it's an entirely new family) and the variant styles to the `$o-fonts-families` map:
+1. Open `src/scss/_variables.scss` and add the font family name (if it's an entirely new family) and the variant styles to the `$o-fonts-families` map:
 
 ```scss
 $o-fonts-families: (
@@ -178,30 +138,18 @@ $o-fonts-families: (
 );
 ```
 
-And then, if it's a new family, add a new entry in `demos/src/config.json`, like so:
+2. Second, if adding an entirely new font, indicate brand support by adding the font name to `$_o-fonts-default-families`. This will determine when the [font is included by default](#fonts-included-by-default).
 
-    "demos": {
-	  "metricweb": {
-	    "data": { "font": "metricweb" }
-	  },
+3. Finally, update the demos (see `origami.json`).
 
-And a new entry in `demos/src/demo.scss`:
-
-```css
-.demo-family-metricweb .demo-example {
-	font-family: oFontsGetFontFamilyWithFallback(MetricWeb);
-}
-```
-
-----
+---
 
 ## Contact
 
 If you have any questions or comments about this component, or need help using it, please either [raise an issue](https://github.com/Financial-Times/o-fonts/issues), visit [#ft-origami](https://financialtimes.slack.com/messages/ft-origami/) or email [Origami Support](mailto:origami-support@ft.com).
 
-
 ----
 
-## License
+## Licence
 
-This software is published under the [MIT licence](http://opensource.org/licenses/MIT).
+This software is published by the Financial Times under the [MIT licence](http://opensource.org/licenses/MIT).

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To include [default fonts for your brand](#fonts-included-by-default), call `oFo
 @include oFonts();
 ```
 
-_If you want to include a font which is provided by Origami but not included by for your brand default, [specifically load the font](#loading-specific-web-fonts–provided-by-origami) separately._
+_If you want to include a font which is provided by Origami but not included by for your brand default, [specifically load the font](#loading-specific-web-fonts-provided-by-origami) separately._
 
 ### Loading specific web fonts provided by Origami
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# o-fonts [![Build Status](https://circleci.com/gh/Financial-Times/o-fonts.png?style=shield&circle-token=c29a1b0246bd3bbad4da8e024954af6c8dc04dca)](https://circleci.com/gh/Financial-Times/o-fonts) [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](#licence)
+o-fonts [![Build Status](https://circleci.com/gh/Financial-Times/o-fonts.png?style=shield&circle-token=c29a1b0246bd3bbad4da8e024954af6c8dc04dca)](https://circleci.com/gh/Financial-Times/o-fonts) [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](#licence)
 =================
 
 _Use `o-fonts` to include Origami provided fonts, or register supported custom fonts._
@@ -26,15 +26,15 @@ Any of the below fonts may be included with `o-fonts` using [SASS](#sass). But t
 | bold     |                     |    ✓ i    |
 | black    |                     |           |
 
-✓: normal style available
-i: italic style available (if not, faux-italic will be displayed)
+- **✓**: normal style available
+- **i**: italic style available (if not, faux-italic will be displayed)
 
 ## Fonts Included By Default
 
 Font faces included by default, if using the Origami Build Service or [including default fonts with SASS](#include-default-fonts), depends on your products chosen brand:
 
 | Brand       | Fonts included by default (all weights and styles) |
-|-------------|:--------------------------------------------------:|
+|-------------|----------------------------------------------------|
 | master      | FinancierDisplayWeb, MetricWeb                     |
 | internal    | MetricWeb                                          |
 | whitelabel  | _(none)_                                           |

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ To include [default fonts for your brand](#fonts-included-by-default), call `oFo
 @include oFonts();
 ```
 
-_If you want to include a font which is provided by Origami but not included by for your brand default, [specifically load the font](#loading-specific-web-fonts-provided-by-origami) separately._
+_If you want to include an Origami font which is not included by default for your brand, [specifically load the font](#load-a-specific-web-font-provided-by-origami) separately._
 
-### Loading specific web fonts provided by Origami
+### Load a specific web font provided by Origami
 
 ```scss
 @import 'o-fonts/main';
@@ -91,7 +91,7 @@ In this example we register a custom font "MyFont" with sans fallback `MyFont, s
 };
 ```
 
-### Get font families for a font
+### Get a font family for a font name
 
 To get a `font-family` with web safe fallbacks for a font, use the `oFontsGetFontFamilyWithFallbacks` function.
 
@@ -99,7 +99,7 @@ To get a `font-family` with web safe fallbacks for a font, use the `oFontsGetFon
 $family: oFontsGetFontFamilyWithFallbacks(FinancierDisplayWeb); // FinancierDisplayWeb, sans-serif
 ```
 
-### Get a font from a font families
+### Get a font name from a font family
 
 To get a font without fallbacks, use `oFontsGetFontFamilyWithoutFallbacks`:
 
@@ -118,7 +118,7 @@ $allowed: oFontsVariantExists('MetricWeb', 'black', 'italic'); // false
 
 ## Contributing
 
-### Adding new font variants
+### Add a new font or font variant
 
 Note: font files are contained in a separate, private repository ([o-fonts-assets](https://github.com/Financial-Times/o-fonts-assets)).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-o-fonts [![Circle CI](https://circleci.com/gh/Financial-Times/o-fonts/tree/master.svg?style=svg)](https://circleci.com/gh/Financial-Times/o-fonts/tree/master)
+# o-fonts [![Build Status](https://circleci.com/gh/Financial-Times/o-fonts.png?style=shield&circle-token=c29a1b0246bd3bbad4da8e024954af6c8dc04dca)](https://circleci.com/gh/Financial-Times/o-fonts) [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](#licence)
 =================
 
 _Use `o-fonts` to include Origami provided fonts, or register supported custom fonts._
@@ -31,7 +31,7 @@ i: italic style available (if not, faux-italic will be displayed)
 
 ## Fonts Included By Default
 
-Font faces included by default, if using the Origami Build Service or [including all fonts with SASS](#sass), depends on your products chosen brand:
+Font faces included by default, if using the Origami Build Service or [including default fonts with SASS](#include-default-fonts), depends on your products chosen brand:
 
 | Brand       | Fonts included by default (all weights and styles) |
 |-------------|:--------------------------------------------------:|
@@ -41,13 +41,13 @@ Font faces included by default, if using the Origami Build Service or [including
 
 ## Sass
 
-### Include All Default Fonts
+### Include Default Fonts
 
-To include [all default fonts for your brand](#fonts-included-by-default), call `oFontsIncludeAll`.
+To include [default fonts for your brand](#fonts-included-by-default), call `oFonts`.
 
 ```scss
 @import 'o-fonts/main';
-@include oFontsIncludeAll();
+@include oFonts();
 ```
 
 _If you want to include a font which is provided by Origami but not included by for your brand default, [specifically load the font](#loading-specific-web-fonts–provided-by-origami) separately._

--- a/README.md
+++ b/README.md
@@ -91,23 +91,23 @@ In this example we register a custom font "MyFont" with sans fallback `MyFont, s
 };
 ```
 
-### Specifying font families
+### Get font families for a font
 
 To get a `font-family` with web safe fallbacks for a font, use the `oFontsGetFontFamilyWithFallbacks` function.
 
 ```scss
-.my-class {
-	font-family: oFontsGetFontFamilyWithFallbacks(FinancierDisplayWeb); // FinancierDisplayWeb, sans-serif
-}
+$family: oFontsGetFontFamilyWithFallbacks(FinancierDisplayWeb); // FinancierDisplayWeb, sans-serif
 ```
 
-To get a font without the fallbacks, use `oFontsGetFontFamilyWithoutFallbacks`:
+### Get a font from a font families
+
+To get a font without fallbacks, use `oFontsGetFontFamilyWithoutFallbacks`:
 
 ```scss
-	$without-fallbacks: oFontsGetFontFamilyWithoutFallbacks('FinancierDisplayWeb, sans-serif'); // FinancierDisplayWeb
+$font: oFontsGetFontFamilyWithoutFallbacks('FinancierDisplayWeb, sans-serif'); // FinancierDisplayWeb
 ```
 
-### Checking a weight or style is allowed
+### Check a font of weight or style exists
 
 To check if a font supports a weight/style use `oFontsVariantExists`.
 

--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,12 @@
 {
-    "name": "o-fonts",
-    "main": ["main.scss"],
-    "ignore": [""]
+  "name": "o-fonts",
+  "main": [
+    "main.scss"
+  ],
+  "ignore": [
+    ""
+  ],
+  "dependencies": {
+    "o-brand": ">=2.3.0 <4"
+  }
 }

--- a/main.scss
+++ b/main.scss
@@ -1,3 +1,5 @@
+@import "o-brand/main";
+
 @import "src/scss/variables";
 @import "src/scss/functions";
 @import "src/scss/mixins";

--- a/main.scss
+++ b/main.scss
@@ -8,7 +8,7 @@
 @mixin oFonts {
 	@each $family in $_o-fonts-default-families {
 		$properties: map-get($o-fonts-families, $family);
-		@if has not map-get($properties, 'custom') {
+		@if not map-get($properties, 'custom') {
 			@each $variant in map-get($properties, variants) {
 				@include oFontsInclude($family, map-get($variant, weight), map-get($variant, style));
 			}

--- a/main.scss
+++ b/main.scss
@@ -4,6 +4,18 @@
 @import "src/scss/functions";
 @import "src/scss/mixins";
 
+/// Output all default Font-face declarations for the current brand.
+@mixin oFonts {
+	@each $family in $_o-fonts-default-families {
+		$properties: map-get($o-fonts-families, $family);
+		@if has not map-get($properties, 'custom') {
+			@each $variant in map-get($properties, variants) {
+				@include oFontsInclude($family, map-get($variant, weight), map-get($variant, style));
+			}
+		}
+	}
+}
+
 @if ($o-fonts-is-silent == false) {
-	@include oFontsIncludeAll();
+	@include oFonts();
 }

--- a/origami.json
+++ b/origami.json
@@ -3,6 +3,11 @@
 	"origamiType": "module",
 	"origamiCategory": "primitives",
 	"origamiVersion": 1,
+	"brands": [
+		"master",
+		"internal",
+		"whitelabel"
+	],
 	"support": "https://github.com/Financial-Times/o-fonts/issues",
 	"supportContact": {
 		"email": "origami.support@ft.com",
@@ -23,7 +28,11 @@
 			"data": {
 				"font": "metricweb"
 			},
-			"description": "Metric is used for utility text, eg categories, tags and navigation",
+			"brands": [
+				"master",
+				"internal"
+			],
+			"description": "Metric is used for general text, utility text, eg categories, tags and navigation",
 			"display_html": false
 		},
 		{
@@ -32,6 +41,9 @@
 			"data": {
 				"font": "financierdisplayweb"
 			},
+			"brands": [
+				"master"
+			],
 			"description": "Financier Display is used for headlines and editorial content at large sizes.",
 			"display_html": false
 		}

--- a/origami.json
+++ b/origami.json
@@ -5,8 +5,7 @@
 	"origamiVersion": 1,
 	"brands": [
 		"master",
-		"internal",
-		"whitelabel"
+		"internal"
 	],
 	"support": "https://github.com/Financial-Times/o-fonts/issues",
 	"supportContact": {

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -77,7 +77,7 @@
 /// @deprecated Use oFonts instead.
 @mixin oFontsIncludeAll {
 	@each $family, $properties in $o-fonts-families {
-		@if has not map-get($properties, 'custom') {
+		@if not map-get($properties, 'custom') {
 			@each $variant in map-get($properties, variants) {
 				@include oFontsInclude($family, map-get($variant, weight), map-get($variant, style));
 			}

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -73,10 +73,10 @@
 	}
 }
 
-/// Output all default Font-face declarations.
+/// Output all Font-face declarations.
+/// @deprecated Use oFonts instead.
 @mixin oFontsIncludeAll {
-	@each $family in $_o-fonts-default-families {
-		$properties: map-get($o-fonts-families, $family);
+	@each $family, $properties in $o-fonts-families {
 		@if has not map-get($properties, 'custom') {
 			@each $variant in map-get($properties, variants) {
 				@include oFontsInclude($family, map-get($variant, weight), map-get($variant, style));

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -73,10 +73,11 @@
 	}
 }
 
-/// Output all Font-face declarations which are provided by Origami.
+/// Output all default Font-face declarations.
 @mixin oFontsIncludeAll {
-	@each $family, $properties in $o-fonts-families {
-		@if not map-get($properties, 'custom') {
+	@each $family in $_o-fonts-default-families {
+		$properties: map-get($o-fonts-families, $family);
+		@if has not map-get($properties, 'custom') {
 			@each $variant in map-get($properties, variants) {
 				@include oFontsInclude($family, map-get($variant, weight), map-get($variant, style));
 			}

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -73,7 +73,7 @@
 	}
 }
 
-/// Output all Font-face declarations.
+/// Output all Font-face declarations which are provided by Origami.
 /// @deprecated Use oFonts instead.
 @mixin oFontsIncludeAll {
 	@each $family, $properties in $o-fonts-families {

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -8,7 +8,19 @@ $o-fonts-path: 'https://www.ft.com/__origami/service/build/v2/files/o-fonts-asse
 /// @type Bool
 $o-fonts-is-silent: true !default;
 
-/// Font families
+/// The font families to include by default, which may vary per brand.
+/// @see oFontsIncludeAll
+/// @access private
+$_o-fonts-default-families: ();
+@if oBrandGetCurrentBrand() == 'master' {
+	$_o-fonts-default-families: ('MetricWeb', 'FinancierDisplayWeb')!global;
+}
+
+@if oBrandGetCurrentBrand() == 'internal' {
+	$_o-fonts-default-families: ('MetricWeb')!global;
+}
+
+/// All available font families.
 ///
 /// @type Map
 $o-fonts-families: (

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -9,7 +9,7 @@ $o-fonts-path: 'https://www.ft.com/__origami/service/build/v2/files/o-fonts-asse
 $o-fonts-is-silent: true !default;
 
 /// The font families to include by default, which may vary per brand.
-/// @see oFontsIncludeAll
+/// @see oFonts
 /// @access private
 $_o-fonts-default-families: ();
 @if oBrandGetCurrentBrand() == 'master' {


### PR DESCRIPTION
Brand `o-fonts` so only the used font faces are included by default (build service or with silent mode off). This is driven by [o-typography branding](https://github.com/Financial-Times/o-typography/pull/166), which currently includes unused fonts.

- Adds a dependancy on `o-brand`.
- Adds a primary mixin `oFonts`, which outputs all fonts for the current brand.
- Only outputs fonts for the current brand via the build service / silent mode:
    - Master: no change.
    - Internal: `FinancierDisplayWeb` is no longer included by the build service or with silent mode off. This is potentially visually breaking but `FinancierDisplayWeb` should not be in use by an internal product.
    - Whitelabel: No fonts included by the build service or with silent mode off.
- Continues to allow any font to be included explicitly, so a whitelabel product can decide to include MetricWeb for example.
- Rewrites the README 🎉 

I had to remove `whitelabel` from origami.json, as `o-fonts` no longer outputs CSS for the whitelabel brand which caused OBT to error. Unsure how to tackle that one yet. 🤔 