### PR TITLE
Confirm whitelabel support.

### DIFF
--- a/origami.json
+++ b/origami.json
@@ -5,7 +5,8 @@
 	"origamiVersion": 1,
 	"brands": [
 		"master",
-		"internal"
+		"internal",
+		"whitelabel"
 	],
 	"support": "https://github.com/Financial-Times/o-fonts/issues",
 	"supportContact": {


### PR DESCRIPTION
`o-fonts` does support the whitelabel brand -- it doesn't output any fonts by default, but can be used for its mixins and functions.