### PR TITLE
Support primary mixin options (plus font-display)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,30 @@
 ## Migration guide
 
 ### Migrating from v3 to v4
+
+The Sass variable `$o-fonts-families` is now private. Use `oFonts` options to include fonts granularly and `oFontsDefineCustomFont` to register new fonts. Contact the Origami team if you need this variable for any other reason.
+
+The Sass mixin `oFontsInclude` is now private. Replace with a single call to `oFonts` and the correct options.
+
+```diff
+-@include oFontsInclude(FinancierDisplayWeb);
+-@include oFontsInclude(FinancierDisplayWeb, $weight: bold);
+-@include oFontsInclude(MetricWeb);
+-@include oFontsInclude(MetricWeb, $weight: semibold);
+-@include oFontsInclude(MetricWeb, $weight: medium);
++@include oFonts($opts: (
++	'metric': (
++        ('weight': 'regular', 'style': 'normal'),
++        ('weight': 'semibold', 'style': 'normal'),
++        ('weight': 'medium', 'style': 'normal'),
++    ),
++	'financier-display': (
++        ('weight': 'regular', 'style': 'normal'),
++        ('weight': 'bold', 'style': 'normal'),
++    )
++));
+```
+
 ### Migrating from v2 to v3
 
 v3 removes Benton, Miller, and FinancierTextWeb fonts. Ensure your project does not use these fonts.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,7 +4,7 @@
 
 The Sass variable `$o-fonts-families` is now private. Use `oFonts` options to include fonts granularly and `oFontsDefineCustomFont` to register new fonts. Contact the Origami team if you need this variable for any other reason.
 
-The Sass mixin `oFontsInclude` is now private. Replace with a single call to `oFonts` and the correct options.
+The Sass mixin `oFontsInclude` and deprecated mixin `oFontsIncludeAll` is now private. Replace with a single call to `oFonts` and the correct options.
 
 ```diff
 -@include oFontsInclude(FinancierDisplayWeb);

--- a/README.md
+++ b/README.md
@@ -50,20 +50,19 @@ To include [default fonts for your brand](#fonts-included-by-default), call `oFo
 @include oFonts();
 ```
 
-_If you want to include an Origami font which is not included by default for your brand, [specifically load the font](#load-a-specific-web-font-provided-by-origami) separately._
+You may also include specific fonts granularly using an options `$opts` map. The map has a key for each font `metric` or `financier-display`, which accepts a list of weight and styles to include.
 
-### Load a specific web font provided by Origami
-
+For example to include font faces for `MetricWeb` in normal and semibold weights, and regular `FinancierDisplayWeb`:
 ```scss
-@import 'o-fonts/main';
-
-// @font-face declarations for all Financier Display weights
-@include oFontsInclude(FinancierDisplayWeb, light);
-@include oFontsInclude(FinancierDisplayWeb, regular);
-@include oFontsInclude(FinancierDisplayWeb, bold);
-
-// @font-face declarations for Metric regular / italic
-@include oFontsInclude(MetricWeb, $weight: regular, $style: italic);
+@include oFonts($opts: (
+	'metric': (
+        ('weight': 'regular', 'style': 'normal'),
+        ('weight': 'semibold', 'style': 'normal')
+    ),
+	'financier-display': (
+        ('weight': 'regular', 'style': 'normal')
+    )
+));
 ```
 
 ### Use a custom font family
@@ -122,23 +121,9 @@ $allowed: oFontsVariantExists('MetricWeb', 'black', 'italic'); // false
 
 Note: font files are contained in a separate, private repository ([o-fonts-assets](https://github.com/Financial-Times/o-fonts-assets)).
 
-1. Open `src/scss/_variables.scss` and add the font family name (if it's an entirely new family) and the variant styles to the `$o-fonts-families` map:
+1. Open `src/scss/_variables.scss` and add the font family name (if it's an entirely new family) and the variant styles to the private `$_o-fonts-families` map.
 
-```scss
-$o-fonts-families: (
-	MetricWeb: (
-		font-family: 'MetricWeb, sans-serif',
-		variants: (
-			(weight: lighter, style: normal),
-			(weight: normal,  style: normal),
-			(weight: bold,    style: normal)
-		)
-	),
-	// …
-);
-```
-
-2. Second, if adding an entirely new font, indicate brand support by adding the font name to `$_o-fonts-default-families`. This will determine when the [font is included by default](#fonts-included-by-default).
+2. Second, if adding an entirely new font, add a new option to the `oFonts` mixin. To include the new [font by default](#fonts-included-by-default) for only some brands assign a variable of default variants conditionally (see `$_o-fonts-default-financier-display-variants`).
 
 3. Finally, update the demos (see `origami.json`).
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,19 @@ For example to include font faces for `MetricWeb` in normal and semibold weights
 ));
 ```
 
+### Font Loading
+
+By default [font-display](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display) is set to `swap`. In supporting browsers a system font is shown until fonts are loaded. To update your font loading method set `$o-fonts-display` at the top of your Sass, before including any other component.
+
+```scss
+// Customise font loading.
+$o-fonts-display: 'optional';
+@import 'o-fonts/main';
+
+
+@include oFonts();
+```
+
 ### Use a custom font family
 
 To register a custom font and supported variants, use the mixin `oFontsDefineCustomFont`.

--- a/main.scss
+++ b/main.scss
@@ -4,14 +4,56 @@
 @import "src/scss/functions";
 @import "src/scss/mixins";
 
-/// Output all default Font-face declarations for the current brand.
-@mixin oFonts {
-	@each $family in $_o-fonts-default-families {
-		$properties: map-get($o-fonts-families, $family);
-		@if not map-get($properties, 'custom') {
-			@each $variant in map-get($properties, variants) {
-				@include oFontsInclude($family, map-get($variant, weight), map-get($variant, style));
+/// Output all default font-face declarations for the current brand.
+///
+/// @example Include all fonts for the current brand (master, internal, whitelabel).
+///     @include oFonts();
+///
+/// @example Include only regular and semibold MetricWeb font faces.
+///     @include oFonts($opts: ('metric': (
+///     	(weight: regular, style: normal),
+///     	(weight: semibold, style: normal),
+///     )));
+///
+/// @example Include only regular and bold FinancierDisplayWeb font faces.
+///     @include oFonts($opts: ('financier-display': (
+///     	(weight: regular, style: normal),
+///     	(weight: semibold, style: normal),
+///     )));
+///
+/// @example Include only regular font faces for MetricWeb and FinancierDisplayWeb.
+///     @include oFonts($opts: (
+///     	'metric': ((weight: regular, style: normal)),
+///     	'financier-display': ((weight: regular, style: normal))
+///     ));
+@mixin oFonts($opts: (
+	'metric': $_o-fonts-default-metric-variants,
+	'financier-display': $_o-fonts-default-financier-display-variants,
+	'display': null
+)) {
+	// Map of options to font name.
+	$fonts: (
+		'metric': 'MetricWeb',
+		'financier-display': 'FinancierDisplayWeb'
+	);
+	// Include each font variant given.
+	@each $option, $family in $fonts {
+		$variants: map-get($opts, $option);
+		$variants: if($variants, $variants, ());
+		@each $variant in $variants {
+			// Validate that the variant style and weight is given.
+			$weight: map-get($variant, 'weight');
+			$style: map-get($variant, 'style');
+			@if(type-of($weight) != 'string') {
+				@error 'Could not include the "#{$family}" font with weight "#{inspect($weight)}". Excepted a string.';
 			}
+			@if(type-of($style) != 'string') {
+				@error 'Could not include the "#{$family}" font with style "#{inspect($style)}". Excepted a string.';
+			}
+			// Get the chosen `font-display`.
+			$display: map-get($opts, 'display');
+			// Include the font face for this variant.
+			@include oFontsInclude($family, $weight, $style, $display);
 		}
 	}
 }

--- a/main.scss
+++ b/main.scss
@@ -28,8 +28,7 @@
 ///     ));
 @mixin oFonts($opts: (
 	'metric': $_o-fonts-default-metric-variants,
-	'financier-display': $_o-fonts-default-financier-display-variants,
-	'display': null
+	'financier-display': $_o-fonts-default-financier-display-variants
 )) {
 	// Map of options to font name.
 	$fonts: (
@@ -50,10 +49,8 @@
 			@if(type-of($style) != 'string') {
 				@error 'Could not include the "#{$family}" font with style "#{inspect($style)}". Excepted a string.';
 			}
-			// Get the chosen `font-display`.
-			$display: map-get($opts, 'display');
 			// Include the font face for this variant.
-			@include oFontsInclude($family, $weight, $style, $display);
+			@include _oFontsInclude($family, $weight, $style);
 		}
 	}
 }

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -1,7 +1,7 @@
 /// Check if a font variant exists for a family.
 ///
 /// @access public
-/// @param {String} $family - one of $o-fonts-families
+/// @param {String} $family - one of $_o-fonts-families
 /// @param {String} $weight [regular] - The font weight.
 /// @param {String} $style [normal] - The font style.
 /// @return {Bool}
@@ -9,7 +9,7 @@
 @function oFontsVariantExists($family, $weight, $style) {
 	$weight: if($weight, $weight, 'regular'); // Handles a falsy `$weight` value.
 	$style: if($style, $style, 'normal'); // Handles a falsy `$style` value.
-	$font-properties: map-get($o-fonts-families, $family);
+	$font-properties: map-get($_o-fonts-families, $family);
 	// Font is not registered.
 	@if type-of($font-properties) != 'map' {
 		@warn 'Could not find any supported font variants for "#{$family}". See `oFontsDefineCustomFont` to register a font and its supported weights/styles.';
@@ -54,11 +54,11 @@
 	}
 
 
-	@if map-has-key($o-fonts-families, $family) {
-		$properties: map-get($o-fonts-families, $family);
+	@if map-has-key($_o-fonts-families, $family) {
+		$properties: map-get($_o-fonts-families, $family);
 		@return unquote(map-get($properties, font-family));
 	}
-	@warn 'Font #{$family} not found. Must be one of $o-fonts-families.';
+	@warn 'Font #{$family} not found. Must be one of $_o-fonts-families.';
 	@return inherit;
 }
 

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -76,18 +76,6 @@
 	}
 }
 
-/// Output all Font-face declarations which are provided by Origami.
-/// @deprecated Use oFonts instead.
-@mixin _oFontsIncludeAll {
-	@each $family, $properties in $_o-fonts-families {
-		@if not map-get($properties, 'custom') {
-			@each $variant in map-get($properties, variants) {
-				@include _oFontsInclude($family, map-get($variant, weight), map-get($variant, style));
-			}
-		}
-	}
-}
-
 /// Output custom Font-face declarations and register the family and variants with o-fonts.
 ///
 /// @example This example shows registering a custom font "MyFont" with "sans" fallback. The font allows regular or bold variants.

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -10,7 +10,8 @@
 /// @param {String} $family - one of $o-fonts-families
 /// @param {String} $weight [regular] - one of $_o-fonts-weights
 /// @param {String} $style [normal]
-@mixin oFontsInclude($family, $weight: regular, $style: normal) {
+/// @param {String|Null} $display [null] - the font-display property for this font face
+@mixin oFontsInclude($family, $weight: regular, $style: normal, $display: null) {
 	@if $family == 'Clarion' or $family == 'Benton' or $family == 'Miller' or $family == 'FinancierTextWeb' {
 		@error "#{$family} has been removed, no font will be included.";
 	}
@@ -65,6 +66,7 @@
 				font-family: $family;
 				font-weight: oFontsWeight($weight);
 				font-style: $style;
+				font-display: $display;
 			}
 
 			// Add to the list of already included families / variants

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -7,11 +7,12 @@
 
 /// Output a Font-face declaration for a given font family which is provided by Origami.
 ///
-/// @param {String} $family - one of $o-fonts-families
+/// @param {String} $family - one of $_o-fonts-families
 /// @param {String} $weight [regular] - one of $_o-fonts-weights
 /// @param {String} $style [normal]
-/// @param {String|Null} $display [null] - the font-display property for this font face
-@mixin oFontsInclude($family, $weight: regular, $style: normal, $display: null) {
+/// @param {String|Null} $display - the font-display property for this font face, defaults to $o-fonts-display
+/// @access private
+@mixin _oFontsInclude($family, $weight: regular, $style: normal, $display: $o-fonts-display) {
 	@if $family == 'Clarion' or $family == 'Benton' or $family == 'Miller' or $family == 'FinancierTextWeb' {
 		@error "#{$family} has been removed, no font will be included.";
 	}
@@ -21,8 +22,8 @@
 	}
 
 	// Check the font is an Origami font, not a custom font.
-	@if map-has-key($o-fonts-families, $family) {
-		$font-family-config: map-get($o-fonts-families, $family);
+	@if map-has-key($_o-fonts-families, $family) {
+		$font-family-config: map-get($_o-fonts-families, $family);
 		@if map-get($font-family-config, 'custom') {
 			@error 'Can not include a custom font "#{$family}". Include your custom font manually.';
 		}
@@ -34,8 +35,8 @@
 	$font-is-already-included: map-has-key($_o-fonts-families-included, #{$family}-#{$weight}-#{$style});
 
 	@if $font-is-already-included == false {
-		@if map-has-key($o-fonts-families, $family) == false {
-			@warn 'Font #{$family} not found. Must be one of $o-fonts-families.';
+		@if map-has-key($_o-fonts-families, $family) == false {
+			@warn 'Font #{$family} not found. Must be one of $_o-fonts-families.';
 		} @else {
 			@if (oFontsVariantExists($family, $weight, $style)) {
 				$font-exists: true;
@@ -77,11 +78,11 @@
 
 /// Output all Font-face declarations which are provided by Origami.
 /// @deprecated Use oFonts instead.
-@mixin oFontsIncludeAll {
-	@each $family, $properties in $o-fonts-families {
+@mixin _oFontsIncludeAll {
+	@each $family, $properties in $_o-fonts-families {
 		@if not map-get($properties, 'custom') {
 			@each $variant in map-get($properties, variants) {
-				@include oFontsInclude($family, map-get($variant, weight), map-get($variant, style));
+				@include _oFontsInclude($family, map-get($variant, weight), map-get($variant, style));
 			}
 		}
 	}
@@ -125,10 +126,10 @@
 		}
 	}
 	$font-key: oFontsGetFontFamilyWithoutFallbacks($font-family);
-	$o-fonts-families: map-merge(($font-key: (
+	$_o-fonts-families: map-merge(($font-key: (
 		'font-family': $font-family,
 		'variants': $variants,
 		'custom': true
-	)), $o-fonts-families) !global;
+	)), $_o-fonts-families) !global;
 	@content; // Output a custom Font-face declaration.
 }

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -8,16 +8,44 @@ $o-fonts-path: 'https://www.ft.com/__origami/service/build/v2/files/o-fonts-asse
 /// @type Bool
 $o-fonts-is-silent: true !default;
 
-/// The font families to include by default, which may vary per brand.
+$_o-fonts-all-metric-variants: (
+	(weight: thin, style: normal),
+	(weight: light, style: normal),
+	(weight: light, style: italic),
+	(weight: regular, style: normal),
+	(weight: regular, style: italic),
+	(weight: medium, style: normal),
+	(weight: semibold, style: normal),
+	(weight: bold, style: normal),
+	(weight: bold, style: italic),
+);
+
+$_o-fonts-all-financier-display-variants: (
+	(weight: light, style: italic),
+	(weight: regular, style: normal),
+	(weight: medium, style: italic),
+	(weight: semibold, style: italic),
+	(weight: bold, style: normal)
+);
+
+/// The MetricWeb variants to include by default, which may vary per brand.
 /// @see oFonts
 /// @access private
-$_o-fonts-default-families: ();
+$_o-fonts-default-metric-variants: ();
+
+/// The FinancierDisplayWeb font variants to include by default, which may vary per brand.
+/// @see oFonts
+/// @access private
+$_o-fonts-default-financier-display-variants: ();
+
 @if oBrandGetCurrentBrand() == 'master' {
-	$_o-fonts-default-families: ('MetricWeb', 'FinancierDisplayWeb')!global;
+	$_o-fonts-default-metric-variants: $_o-fonts-all-metric-variants !global;
+	$_o-fonts-default-financier-display-variants: $_o-fonts-all-financier-display-variants !global;
 }
 
 @if oBrandGetCurrentBrand() == 'internal' {
-	$_o-fonts-default-families: ('MetricWeb')!global;
+	$_o-fonts-default-metric-variants: $_o-fonts-all-metric-variants !global;
+	$_o-fonts-default-financier-display-variants: () !global;
 }
 
 /// All available font families.
@@ -26,27 +54,11 @@ $_o-fonts-default-families: ();
 $o-fonts-families: (
 	MetricWeb: (
 		font-family: 'MetricWeb, sans-serif',
-		variants: (
-			(weight: thin, style: normal),
-			(weight: light, style: normal),
-			(weight: light, style: italic),
-			(weight: regular, style: normal),
-			(weight: regular, style: italic),
-			(weight: medium, style: normal),
-			(weight: semibold, style: normal),
-			(weight: bold, style: normal),
-			(weight: bold, style: italic),
-		)
+		variants: $_o-fonts-all-metric-variants
 	),
 	FinancierDisplayWeb: (
 		font-family: 'FinancierDisplayWeb, serif',
-		variants: (
-			(weight: light, style: italic),
-			(weight: regular, style: normal),
-			(weight: medium, style: italic),
-			(weight: semibold, style: italic),
-			(weight: bold, style: normal)
-		)
+		variants: $_o-fonts-all-financier-display-variants
 	),
 ) !default;
 

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -8,6 +8,15 @@ $o-fonts-path: 'https://www.ft.com/__origami/service/build/v2/files/o-fonts-asse
 /// @type Bool
 $o-fonts-is-silent: true !default;
 
+/// The default `font-display` property of included font faces.
+/// https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display
+///
+/// @type String|Null
+$o-fonts-display: 'swap' !default;
+
+/// A list of all weight and style variants of the MetricWeb font.
+/// @type List
+/// @access private
 $_o-fonts-all-metric-variants: (
 	(weight: thin, style: normal),
 	(weight: light, style: normal),
@@ -20,6 +29,9 @@ $_o-fonts-all-metric-variants: (
 	(weight: bold, style: italic),
 );
 
+/// A list of all weight and style variants of the FinancierDisplayWeb font.
+/// @type List
+/// @access private
 $_o-fonts-all-financier-display-variants: (
 	(weight: light, style: italic),
 	(weight: regular, style: normal),
@@ -28,12 +40,12 @@ $_o-fonts-all-financier-display-variants: (
 	(weight: bold, style: normal)
 );
 
-/// The MetricWeb variants to include by default, which may vary per brand.
+/// The MetricWeb variants to include by default, which vary per brand.
 /// @see oFonts
 /// @access private
 $_o-fonts-default-metric-variants: ();
 
-/// The FinancierDisplayWeb font variants to include by default, which may vary per brand.
+/// The FinancierDisplayWeb font variants to include by default, which vary per brand.
 /// @see oFonts
 /// @access private
 $_o-fonts-default-financier-display-variants: ();
@@ -51,7 +63,8 @@ $_o-fonts-default-financier-display-variants: ();
 /// All available font families.
 ///
 /// @type Map
-$o-fonts-families: (
+/// @access private
+$_o-fonts-families: (
 	MetricWeb: (
 		font-family: 'MetricWeb, sans-serif',
 		variants: $_o-fonts-all-metric-variants

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -1,5 +1,5 @@
 @include test-module('oFontsDefineCustomFont') {
-	@include test('Outputs the custom font face and updates the "$o-fonts-families" map.') {
+	@include test('Outputs the custom font face and updates the "$_o-fonts-families" map.') {
 
         @include assert {
             // Include a custom font with regular and bold variants.
@@ -20,7 +20,7 @@
 
         // The font faces are output.
         @include assert-equal(
-            $o-fonts-families,
+            $_o-fonts-families,
             ("MyFont": ("font-family": "MyFont, sans", "variants": ((weight: regular, style: normal), (weight: bold, style: normal)), "custom": true), MetricWeb: (font-family: "MetricWeb, sans-serif", variants: ((weight: thin, style: normal), (weight: light, style: normal), (weight: light, style: italic), (weight: regular, style: normal), (weight: regular, style: italic), (weight: medium, style: normal), (weight: semibold, style: normal), (weight: bold, style: normal), (weight: bold, style: italic))), FinancierDisplayWeb: (font-family: "FinancierDisplayWeb, serif", variants: ((weight: light, style: italic), (weight: regular, style: normal), (weight: medium, style: italic), (weight: semibold, style: italic), (weight: bold, style: normal))))
         );
 	}


### PR DESCRIPTION
This PR is a bit of a mix and could have been broken down a little.

- Sets [font-display](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display) and gives users the option to customise through a variable.
- Adds options to `oFonts`
- Removes `oFontsInclude` for `oFonts`
- Removes `oFontsIncludeAll` for `oFonts`
- Removes `$o-fonts-families`