### PR TITLE
Remove `oFontsSource`, `oFontsUseAsset`, and error over warn.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -25,7 +25,7 @@ The Sass mixin `oFontsInclude` and deprecated mixin `oFontsIncludeAll` is now pr
 +));
 ```
 
-The Sass mixin `oFontsSource` and function `oFontsUseAsset` have been removed. If you are unable to included your font with `oFonts` please contact the Origami team/
+The Sass mixin `oFontsSource` and function `oFontsUseAsset` have been removed. If you are unable to included your font with `oFonts` please contact the Origami team.
 
 ### Migrating from v2 to v3
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -25,6 +25,8 @@ The Sass mixin `oFontsInclude` and deprecated mixin `oFontsIncludeAll` is now pr
 +));
 ```
 
+The Sass mixin `oFontsSource` and function `oFontsUseAsset` have been removed. If you are unable to included your font with `oFonts` please contact the Origami team/
+
 ### Migrating from v2 to v3
 
 v3 removes Benton, Miller, and FinancierTextWeb fonts. Ensure your project does not use these fonts.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -25,7 +25,7 @@ The Sass mixin `oFontsInclude` and deprecated mixin `oFontsIncludeAll` is now pr
 +));
 ```
 
-The Sass mixin `oFontsSource` and function `oFontsUseAsset` have been removed. If you are unable to included your font with `oFonts` please contact the Origami team.
+The Sass mixin `oFontsSource` and function `oFontsUseAsset` have been removed. If you are unable to include your font with `oFonts` please contact the Origami team.
 
 ### Migrating from v2 to v3
 

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -12,7 +12,6 @@
 	$font-properties: map-get($_o-fonts-families, $family);
 	// Font is not registered.
 	@if type-of($font-properties) != 'map' {
-		@warn 'Could not find any supported font variants for "#{$family}". See `oFontsDefineCustomFont` to register a font and its supported weights/styles.';
 		@return false;
 	}
 	$font-variants: map-get($font-properties, variants);
@@ -27,44 +26,27 @@
 	@return false;
 }
 
-/// Capitalise first letter of $string
-///
-/// @param {String} $string - string to update
-///
-/// @return {String}
-@function _oFontsStringCapitalise($string) {
-	$string: $string + unquote(''); // Make sure $string has a type of String
-	$first-letter: to-upper-case(str-slice($string, 0, 1));
-	$rest-of-string: str-slice($string, 2);
-
-	@return $first-letter + $rest-of-string;
-}
-
 /// Get a font-family stack with the appropriate fallbacks
 ///
-/// @param {String} family
-///
-/// @return {String} - font-stack
-///
 /// @example scss
-/// font-family: oFontsGetFontFamilyWithFallbacks(FinancierDisplayWeb);
+/// 	font-family: oFontsGetFontFamilyWithFallbacks(FinancierDisplayWeb);
+///
+/// @param {String} family
+/// @return {String} - font-stack
 @function oFontsGetFontFamilyWithFallbacks($family) {
-	@if $family == 'Clarion' or $family == 'Benton' or $family == 'Miller' or $family == 'FinancierTextWeb' {
-		@error "#{$family} has been removed. Please use either MetricWeb or FinancierDisplayWeb.";
+	@if not map-has-key($_o-fonts-families, $family) {
+		@error 'Font "#{inspect($family)}" not found. Must be one of #{map-keys($_o-fonts-families)}.';
 	}
 
-
-	@if map-has-key($_o-fonts-families, $family) {
-		$properties: map-get($_o-fonts-families, $family);
-		@return unquote(map-get($properties, font-family));
-	}
-	@warn 'Font #{$family} not found. Must be one of $_o-fonts-families.';
-	@return inherit;
+	$properties: map-get($_o-fonts-families, $family);
+	@return unquote(map-get($properties, font-family));
 }
 
 /// Removes a fonts fallbacks.
+///
 /// @example
 ///     $family: oFontsGetFontFamilyWithoutFallbacks('FinancierDisplayWeb, sans'); //FinancierDisplayWeb
+///
 /// @param {String|List} $family - Font family potentially with fallbacks.
 /// @returns {String} Font family without fallbacks.
 @function oFontsGetFontFamilyWithoutFallbacks($family) {
@@ -78,27 +60,30 @@
 	@return if($family, $family, '');
 }
 
-/// Path to a font asset
-///
-/// @param {String} $asset
-///
-/// @return {String} - Path to the font asset, without the file extension
-@function oFontsUseAsset($asset) {
-	@return $o-fonts-path + $asset;
-}
-
 /// Machine-readable CSS font-weight.
 ///
-/// @param {String} $keyword - Human-readable keyword, one of $_o-fonts-weights
-///
 /// @example scss
-/// font-weight: oFontsWeight(lighter);
+/// 	font-weight: oFontsWeight(lighter);
 ///
+/// @param {String} $keyword - Human-readable keyword e.g. 'semibold', 'regular', 'bold'.
 /// @return {Number} - CSS font-weight
 @function oFontsWeight($keyword) {
-	@if map-has-key($_o-fonts-weights, $keyword) {
-		@return map-get($_o-fonts-weights, $keyword);
-	} @else {
-		@warn 'Keyword "#{$keyword}" not found. Must be one of $_o-fonts-weights.';
+	@if not map-has-key($_o-fonts-weights, $keyword) {
+		@error 'Font weight "#{$keyword}" not found. Must be one of #{inspect(map-keys($_o-fonts-weights))}.';
 	}
+
+	@return map-get($_o-fonts-weights, $keyword);
+}
+
+/// Capitalise first letter of $string
+///
+/// @access private
+/// @param {String} $string - string to update
+/// @return {String} - the string with a capitalised first letter
+@function _oFontsStringCapitalise($string) {
+	$string: $string + unquote(''); // Make sure $string has a type of String
+	$first-letter: to-upper-case(str-slice($string, 0, 1));
+	$rest-of-string: str-slice($string, 2);
+
+	@return $first-letter + $rest-of-string;
 }

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -35,7 +35,7 @@
 /// @return {String} - font-stack
 @function oFontsGetFontFamilyWithFallbacks($family) {
 	@if not map-has-key($_o-fonts-families, $family) {
-		@error 'Font "#{inspect($family)}" not found. Must be one of #{map-keys($_o-fonts-families)}.';
+		@error 'Font "#{inspect($family)}" not found. "$family" must be one of #{map-keys($_o-fonts-families)}.';
 	}
 
 	$properties: map-get($_o-fonts-families, $family);

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -1,81 +1,3 @@
-/// Font-face declaration sources
-///
-/// @param {String} fontName - path to the file, without the file extension
-@mixin oFontsSource($fontName) {
-	src: url(oFontsUseAsset($fontName + '.woff'));
-}
-
-/// Output a Font-face declaration for a given font family which is provided by Origami.
-///
-/// @param {String} $family - one of $_o-fonts-families
-/// @param {String} $weight [regular] - one of $_o-fonts-weights
-/// @param {String} $style [normal]
-/// @param {String|Null} $display - the font-display property for this font face, defaults to $o-fonts-display
-/// @access private
-@mixin _oFontsInclude($family, $weight: regular, $style: normal, $display: $o-fonts-display) {
-	@if $family == 'Clarion' or $family == 'Benton' or $family == 'Miller' or $family == 'FinancierTextWeb' {
-		@error "#{$family} has been removed, no font will be included.";
-	}
-
-	@if $weight == normal {
-		$weight: regular;
-	}
-
-	// Check the font is an Origami font, not a custom font.
-	@if map-has-key($_o-fonts-families, $family) {
-		$font-family-config: map-get($_o-fonts-families, $family);
-		@if map-get($font-family-config, 'custom') {
-			@error 'Can not include a custom font "#{$family}". Include your custom font manually.';
-		}
-	}
-
-	$font-exists: false;
-	// Check if the font has already been included
-	// If so, no need to output another @font-face declaration
-	$font-is-already-included: map-has-key($_o-fonts-families-included, #{$family}-#{$weight}-#{$style});
-
-	@if $font-is-already-included == false {
-		@if map-has-key($_o-fonts-families, $family) == false {
-			@warn 'Font #{$family} not found. Must be one of $_o-fonts-families.';
-		} @else {
-			@if (oFontsVariantExists($family, $weight, $style)) {
-				$font-exists: true;
-			} @else {
-				@warn 'Variant "weight: #{$weight}, style: #{$style}" not found for "#{$family}". @font-face rule will not be output.';
-			}
-		}
-
-		@if ($font-exists) {
-			// Files are named as follows
-			// Name-WeightType
-			// MetricWeb-Regular              (regular normal)
-			// MetricWeb-RegularItalic        (regular italic)
-			// MetricWeb-Bold                 (bold normal)
-			// MetricWeb-BoldItalic           (bold italic)
-
-			// By default, suffix is the weight
-			$font-suffix: _oFontsStringCapitalise($weight);
-
-			@if ($style != 'normal') {
-				$capitalised-weight: _oFontsStringCapitalise($weight);
-				$capitalised-style: _oFontsStringCapitalise($style);
-				$font-suffix: #{$capitalised-weight}#{$capitalised-style};
-			}
-
-			@font-face {
-				@include oFontsSource(#{$family}-#{$font-suffix});
-				font-family: $family;
-				font-weight: oFontsWeight($weight);
-				font-style: $style;
-				font-display: $display;
-			}
-
-			// Add to the list of already included families / variants
-			$_o-fonts-families-included: map-merge($_o-fonts-families-included, (#{$family}-#{$weight}-#{$style}: true)) !global;
-		}
-	}
-}
-
 /// Output custom Font-face declarations and register the family and variants with o-fonts.
 ///
 /// @example This example shows registering a custom font "MyFont" with "sans" fallback. The font allows regular or bold variants.
@@ -120,4 +42,69 @@
 		'custom': true
 	)), $_o-fonts-families) !global;
 	@content; // Output a custom Font-face declaration.
+}
+
+/// Output a Font-face declaration for a given font family which is provided by Origami.
+///
+/// @param {String} $family - one of $_o-fonts-families
+/// @param {String} $weight [regular] - e.g. 'regular', 'semibold', 'bold'
+/// @param {String} $style [normal] - e.g. 'italic'
+/// @param {String|Null} $display - the font-display property for this font face, defaults to $o-fonts-display
+/// @access private
+@mixin _oFontsInclude($family, $weight: regular, $style: normal, $display: $o-fonts-display) {
+	// Help user if they requested a normal rather than regular weight.
+	@if $weight == normal {
+		@warn '"normal" is not a font weight for "#{$family}". Request a "regular" weight instead.';
+		$weight: regular;
+	}
+
+	// Check the font is an Origami font, not a custom font.
+	@if map-has-key($_o-fonts-families, $family) {
+		$font-family-config: map-get($_o-fonts-families, $family);
+		@if map-get($font-family-config, 'custom') {
+			@error 'Can not include a custom font "#{$family}". Include your custom font manually.';
+		}
+	}
+
+	// Check if the font has already been included
+	// If so, no need to output another @font-face declaration
+	$font-is-already-included: map-has-key($_o-fonts-families-included, #{$family}-#{$weight}-#{$style});
+
+	@if $font-is-already-included == false {
+		// Error if a font does not exist for the given variant.
+		@if not map-has-key($_o-fonts-families, $family) {
+			@error 'Font "#{inspect($family)}" not found. Must be one of #{map-keys($_o-fonts-families)}.';
+		}
+
+		@if not oFontsVariantExists($family, $weight, $style) {
+			@error 'Font for "#{$family}" at weight: "#{$weight}" and style "#{$style}" does not exist.';
+		}
+
+		// Files are named as follows
+		// Name-WeightType
+		// MetricWeb-Regular              (regular normal)
+		// MetricWeb-RegularItalic        (regular italic)
+		// MetricWeb-Bold                 (bold normal)
+		// MetricWeb-BoldItalic           (bold italic)
+
+		// By default, suffix is the weight
+		$font-suffix: _oFontsStringCapitalise($weight);
+
+		@if ($style != 'normal') {
+			$capitalised-weight: _oFontsStringCapitalise($weight);
+			$capitalised-style: _oFontsStringCapitalise($style);
+			$font-suffix: #{$capitalised-weight}#{$capitalised-style};
+		}
+
+		@font-face {
+			src: url($o-fonts-path + '#{$family}-#{$font-suffix}' + '.woff');
+			font-family: $family;
+			font-weight: oFontsWeight($weight);
+			font-style: $style;
+			font-display: $display;
+		}
+
+		// Add to the list of already included families / variants
+		$_o-fonts-families-included: map-merge($_o-fonts-families-included, (#{$family}-#{$weight}-#{$style}: true)) !global;
+	}
 }

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -1,12 +1,12 @@
-/// Path to the assets
-///
-/// @type String
-$o-fonts-path: 'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.3.2/' !default;
-
 /// Silent mode
 ///
 /// @type Bool
 $o-fonts-is-silent: true !default;
+
+/// Path to default font files.
+///
+/// @type String
+$o-fonts-path: 'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.3.2/' !default;
 
 /// The default `font-display` property of included font faces.
 /// https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display
@@ -77,9 +77,8 @@ $_o-fonts-families: (
 
 /// Human-readable Font-weights
 ///
-/// @access private
-///
 /// @type Map
+/// @access private
 $_o-fonts-weights: (
 	'thin':       100,
 	'light':      200,


### PR DESCRIPTION
The Sass `oFontsSource` and `oFontsUseAsset` has been removed.
They do no appear to be used publically.

Warnings have been replaced by more strict errors, to avoid
mistakes where warnings are missed or ignored. Warnings from
`oFontsVariantExists` have been removed -- it returns a boolean,
it's up to the consumber whether to warn the user.