### PR TITLE
Enforce unquoted font face property values.

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -100,8 +100,8 @@
 			src: url($o-fonts-path + '#{$family}-#{$font-suffix}' + '.woff');
 			font-family: $family;
 			font-weight: oFontsWeight($weight);
-			font-style: $style;
-			font-display: $display;
+			font-style: unquote($style);
+			font-display: unquote($display);
 		}
 
 		// Add to the list of already included families / variants

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -12,7 +12,7 @@ $o-fonts-path: 'https://www.ft.com/__origami/service/build/v2/files/o-fonts-asse
 /// https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display
 ///
 /// @type String|Null
-$o-fonts-display: 'swap' !default;
+$o-fonts-display: swap !default;
 
 /// A list of all weight and style variants of the MetricWeb font.
 /// @type List


### PR DESCRIPTION
If `oFonts` is called with weights or styles which are quoted
this is passed through to the final font face output. Quoted values
e.g. `font-style: "italic"` are ignored by the browser. This means
the wrong font file may be used depending on source order.