### PR TITLE
Financier new font weight

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Any of the below fonts may be included with `o-fonts` using [SASS](#sass). But t
 | thin     |                     |    ✓      |
 | light    |           i         |    ✓ i    |
 | regular  |         ✓ i         |    ✓ i    |
-| medium   |           i         |    ✓      |
+| medium   |         ✓ i         |    ✓      |
 | semibold |           i         |    ✓      |
 | bold     |         ✓           |    ✓ i    |
 | black    |                     |           |

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -37,6 +37,7 @@ $_o-fonts-all-financier-display-variants: (
 	(weight: regular, style: normal),
 	(weight: regular, style: italic),
 	(weight: medium, style: italic),
+	(weight: medium, style: normal),
 	(weight: semibold, style: italic),
 	(weight: bold, style: normal)
 );

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -21,7 +21,7 @@
         // The font faces are output.
         @include assert-equal(
             $_o-fonts-families,
-            ("MyFont": ("font-family": "MyFont, sans", "variants": ((weight: regular, style: normal), (weight: bold, style: normal)), "custom": true), MetricWeb: (font-family: "MetricWeb, sans-serif", variants: ((weight: thin, style: normal), (weight: light, style: normal), (weight: light, style: italic), (weight: regular, style: normal), (weight: regular, style: italic), (weight: medium, style: normal), (weight: semibold, style: normal), (weight: bold, style: normal), (weight: bold, style: italic))), FinancierDisplayWeb: (font-family: "FinancierDisplayWeb, serif", variants: ((weight: light, style: italic), (weight: regular, style: normal), (weight: regular, style: italic), (weight: medium, style: italic), (weight: semibold, style: italic), (weight: bold, style: normal))))
+            ("MyFont": ("font-family": "MyFont, sans", "variants": ((weight: regular, style: normal), (weight: bold, style: normal)), "custom": true), MetricWeb: (font-family: "MetricWeb, sans-serif", variants: ((weight: thin, style: normal), (weight: light, style: normal), (weight: light, style: italic), (weight: regular, style: normal), (weight: regular, style: italic), (weight: medium, style: normal), (weight: semibold, style: normal), (weight: bold, style: normal), (weight: bold, style: italic))), FinancierDisplayWeb: (font-family: "FinancierDisplayWeb, serif", variants: ((weight: light, style: italic), (weight: regular, style: normal), (weight: regular, style: italic), (weight: medium, style: italic), (weight: medium, style: normal), (weight: semibold, style: italic), (weight: bold, style: normal))))
         );
 	}
 }


### PR DESCRIPTION
As a part of 
https://financialtimes.atlassian.net/browse/AT-3576 changes, 
we would like to be able to use Financier weight 500 for 'normal' style
 