### PR TITLE
Document recommended fonts and include primary mixin option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,67 @@ o-fonts [![Build Status](https://circleci.com/gh/Financial-Times/o-fonts.png?sty
 
 _Use `o-fonts` to include Origami provided fonts, or register supported custom fonts._
 
-- [Fonts Available](#fonts-available)
+- [Recommended Fonts](#recommended-fonts)
 - [Fonts Included By Default](#fonts-included-by-default)
+- [All Available Fonts](#all-available-fonts)
 - [Sass](#sass)
 - [Contributing](#contributing)
 - [Migration guide](#migration)
 - [Contact](#contact)
 - [Licence](#licence)
 
+## Recommended Fonts
 
-## Fonts Available
+Origami components use a limited set of recommended font faces which vary per brand. We recommend [Sass users](#sass) include only these recommended fonts and carefully consider performance implications before including another font. However a wider selection of fonts [are included by default](#fonts-included-by-default) so they are available to Build Service users. [Sass users](#sass) may choose to include only recommended fonts, or any of the [available fonts](#all-available-fonts).
 
-Any of the below fonts may be included with `o-fonts` using [SASS](#sass). But the [fonts included by default](#fonts-included-by-default) vary per brand.
+### Master Brand Recommended Fonts
+
+| Weight   | FinancierDisplayWeb | MetricWeb |
+|----------|:-------------------:|:---------:|
+| thin     |                     |           |
+| light    |                     |           |
+| regular  |                     |    ✓      |
+| medium   |         ✓           |           |
+| semibold |                     |    ✓      |
+| bold     |         ✓           |           |
+| black    |                     |           |
+
+- **✓**: normal style available
+- **i**: italic style available (if not, faux-italic will be displayed)
+
+### Internal Brand Recommended Fonts
+
+| Weight   | MetricWeb |
+|----------|:---------:|
+| thin     |           |
+| light    |           |
+| regular  |    ✓      |
+| medium   |           |
+| semibold |    ✓      |
+| bold     |           |
+| black    |           |
+
+- **✓**: normal style available
+- **i**: italic style available (if not, faux-italic will be displayed)
+
+### Whitelabel Brand Recommended Fonts
+
+_(None)_. Origami components make no font assumptions for whitelabel brands and default to a system font.
+
+## Fonts Included By Default
+
+A selection wider than [recommended fonts](#recommended-fonts) are included by default so they are available to Build Service users. Font faces included by default, if using the Origami Build Service or [including default fonts with SASS](#include-default-fonts), depend on your products chosen brand:
+
+| Brand       | Fonts included by default ([all weights and styles available](#all-available-fonts)) |
+|-------------|--------------------------------------------------------------------------------------|
+| master      | FinancierDisplayWeb, MetricWeb                                                       |
+| internal    | MetricWeb                                                                            |
+| whitelabel  | _(none)_                                                                             |
+
+
+## All Available Fonts
+
+Any of the below fonts may be included with `o-fonts` using [SASS](#sass). Build Service users are limited to [fonts included by default](#fonts-included-by-default).
 
 | Weight   | FinancierDisplayWeb | MetricWeb |
 |----------|:-------------------:|:---------:|
@@ -29,35 +78,31 @@ Any of the below fonts may be included with `o-fonts` using [SASS](#sass). But t
 - **✓**: normal style available
 - **i**: italic style available (if not, faux-italic will be displayed)
 
-## Fonts Included By Default
-
-Font faces included by default, if using the Origami Build Service or [including default fonts with SASS](#include-default-fonts), depends on your products chosen brand:
-
-| Brand       | Fonts included by default (all weights and styles) |
-|-------------|----------------------------------------------------|
-| master      | FinancierDisplayWeb, MetricWeb                     |
-| internal    | MetricWeb                                          |
-| whitelabel  | _(none)_                                           |
-
 ## Sass
 
 ### Include Default Fonts
 
-To include [default fonts for your brand](#fonts-included-by-default), call `oFonts`.
+To include [all fonts for your brand](#fonts-included-by-default), call `oFonts`.
 
 ```scss
 @import 'o-fonts/main';
 @include oFonts();
 ```
 
+To improve site performance, Origami components use a more limited set of font faces. To included only the recommended set of font faces, set `recommended: true` in the options `$opts` map.
+```scss
+@import 'o-fonts/main';
+@include oFonts($opts: ('recommended': true));
+```
+
 You may also include specific fonts granularly using an options `$opts` map. The map has a key for each font `metric` or `financier-display`, which accepts a list of weight and styles to include.
 
-For example to include font faces for `MetricWeb` in normal and semibold weights, and regular `FinancierDisplayWeb`:
+For example to include recommended fonts used by Origami components and an extra font, `MetricWeb` in a medium weight, and regular `FinancierDisplayWeb`:
 ```scss
 @include oFonts($opts: (
+    'recommended': true,
 	'metric': (
-        ('weight': 'regular', 'style': 'normal'),
-        ('weight': 'semibold', 'style': 'normal')
+        ('weight': 'medium', 'style': 'normal')
     ),
 	'financier-display': (
         ('weight': 'regular', 'style': 'normal')
@@ -136,7 +181,7 @@ Note: font files are contained in a separate, private repository ([o-fonts-asset
 
 1. Open `src/scss/_variables.scss` and add the font family name (if it's an entirely new family) and the variant styles to the private `$_o-fonts-families` map.
 
-2. Second, if adding an entirely new font, add a new option to the `oFonts` mixin. To include the new [font by default](#fonts-included-by-default) for only some brands assign a variable of default variants conditionally (see `$_o-fonts-default-financier-display-variants`).
+2. Second, if adding an entirely new font, add a new option to the `oFonts` mixin. To include the new [font by default](#fonts-included-by-default) or with [recommended fonts](#recommended-fonts)  (see `$_o-fonts-default` and `$_o-fonts-recommended`).
 
 3. Finally, update the demos (see `origami.json`).
 

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -1,5 +1,6 @@
-$o-fonts-is-silent: false;
 @import "../../main";
+
+@include oFonts();
 
 .demo-container {
 	margin: 0 20px;

--- a/main.scss
+++ b/main.scss
@@ -9,6 +9,17 @@
 /// @example Include all fonts for the current brand (master, internal, whitelabel).
 ///     @include oFonts();
 ///
+/// @example Include a limited set of recommended fonts for the current brand (master, internal, whitelabel).
+///     @include oFonts($opts: ('recommended': true));
+///
+/// @example Include a limited set of recommended fonts for the current brand, plus an extra FinancierDisplayWeb font.
+/// 	@include oFonts($opts: (
+/// 		'recommended': true,
+/// 		'financier-display': (
+/// 			(weight: regular, style: normal)
+/// 		)
+/// 	));
+///
 /// @example Include only regular and semibold MetricWeb font faces.
 ///     @include oFonts($opts: ('metric': (
 ///     	(weight: regular, style: normal),
@@ -26,10 +37,7 @@
 ///     	'metric': ((weight: regular, style: normal)),
 ///     	'financier-display': ((weight: regular, style: normal))
 ///     ));
-@mixin oFonts($opts: (
-	'metric': $_o-fonts-default-metric-variants,
-	'financier-display': $_o-fonts-default-financier-display-variants
-)) {
+@mixin oFonts($opts: $_o-fonts-default) {
 	// Map of options to font name.
 	$fonts: (
 		'metric': 'MetricWeb',
@@ -37,8 +45,18 @@
 	);
 	// Include each font variant given.
 	@each $option, $family in $fonts {
+		// Get font variants to include from the opt map by font family.
 		$variants: map-get($opts, $option);
 		$variants: if($variants, $variants, ());
+		// Merge recommended font variants if recommended fonts were requested.
+		@if map-get($opts, 'recommended') == true {
+			$recommended-variants: map-get($_o-fonts-recommended, $option);
+			@if length($variants) > 0 {
+				$variants: append($recommended-variants, $variants);
+			} @else {
+				$variants: $recommended-variants;
+			}
+		}
 		@each $variant in $variants {
 			// Validate that the variant style and weight is given.
 			$weight: map-get($variant, 'weight');

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -42,24 +42,54 @@ $_o-fonts-all-financier-display-variants: (
 	(weight: bold, style: normal)
 );
 
-/// The MetricWeb variants to include by default, which vary per brand.
+/// The fonts to include by default, which vary per brand.
 /// @see oFonts
 /// @access private
-$_o-fonts-default-metric-variants: ();
-
-/// The FinancierDisplayWeb font variants to include by default, which vary per brand.
-/// @see oFonts
-/// @access private
-$_o-fonts-default-financier-display-variants: ();
+$_o-fonts-default: ();
 
 @if oBrandGetCurrentBrand() == 'master' {
-	$_o-fonts-default-metric-variants: $_o-fonts-all-metric-variants !global;
-	$_o-fonts-default-financier-display-variants: $_o-fonts-all-financier-display-variants !global;
+	$_o-fonts-default: (
+		'metric': $_o-fonts-all-metric-variants,
+		'financier-display': $_o-fonts-all-financier-display-variants
+	) !global;
 }
 
 @if oBrandGetCurrentBrand() == 'internal' {
-	$_o-fonts-default-metric-variants: $_o-fonts-all-metric-variants !global;
-	$_o-fonts-default-financier-display-variants: () !global;
+	$_o-fonts-default: (
+		'metric': $_o-fonts-all-metric-variants,
+		'financier-display': ()
+	) !global;
+}
+
+/// The MetricWeb variants to include by recommended, which vary per brand.
+/// @see oFonts
+/// @access private
+$_o-fonts-recommended: (
+	'metric': (),
+	'financier-display': ()
+);
+
+@if oBrandGetCurrentBrand() == 'master' {
+	$_o-fonts-recommended: (
+		'metric': (
+			(weight: regular, style: normal),
+			(weight: semibold, style: normal)
+		),
+		'financier-display': (
+			(weight: medium, style: normal),
+			(weight: bold, style: normal)
+		)
+	);
+}
+
+@if oBrandGetCurrentBrand() == 'internal' {
+	$_o-fonts-recommended: (
+		'metric': (
+			(weight: regular, style: normal),
+			(weight: semibold, style: normal)
+		),
+		'financier-display': ()
+	);
 }
 
 /// All available font families.

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -1,3 +1,84 @@
+@include test-module('oFonts') {
+    $original-o-fonts-families-included: $_o-fonts-families-included;
+	@include test('Includes default fonts when given no options') {
+
+       @include oFonts();
+
+        // The font faces are output.
+        // o-fonts keeps track of included fonts, we can't test font-faces
+        // with true-sass so test against this private variable and reset
+        // it for each test :mask:
+        @include assert-equal(
+            $_o-fonts-families-included,
+            (
+                'MetricWeb-thin-normal': true,
+                'MetricWeb-light-normal': true,
+                'MetricWeb-light-italic': true,
+                'MetricWeb-regular-normal': true,
+                'MetricWeb-regular-italic': true,
+                'MetricWeb-medium-normal': true,
+                'MetricWeb-semibold-normal': true,
+                'MetricWeb-bold-normal': true,
+                'MetricWeb-bold-italic': true,
+                'FinancierDisplayWeb-light-italic': true,
+                'FinancierDisplayWeb-regular-normal': true,
+                'FinancierDisplayWeb-regular-italic': true,
+                'FinancierDisplayWeb-medium-italic': true,
+                'FinancierDisplayWeb-medium-normal': true,
+                'FinancierDisplayWeb-semibold-italic': true,
+                'FinancierDisplayWeb-bold-normal': true
+            )
+        );
+        $_o-fonts-families-included: $original-o-fonts-families-included !global;
+    }
+
+	@include test('Includes recommended fonts only when "recommended" option given') {
+
+       @include oFonts(('recommended': true));
+
+        // The font faces are output.
+        // o-fonts keeps track of included fonts, we can't test font-faces
+        // with true-sass so test against this private variable and reset
+        // it for each test :mask:
+        @include assert-equal(
+            $_o-fonts-families-included,
+            (
+                'MetricWeb-regular-normal': true,
+                'MetricWeb-semibold-normal': true,
+                'FinancierDisplayWeb-medium-normal': true,
+                'FinancierDisplayWeb-bold-normal': true
+            )
+        );
+        $_o-fonts-families-included: $original-o-fonts-families-included !global;
+	}
+
+	@include test('Includes recommended fonts and specified addition fonts') {
+
+        @include oFonts($opts: (
+        	'recommended': true,
+        	'financier-display': (
+        		(weight: regular, style: normal) // extra font, not a recommended font
+        	)
+        ));
+
+        // The font faces are output.
+        // o-fonts keeps track of included fonts, we can't test font-faces
+        // with true-sass so test against this private variable and reset
+        // it for each test :mask:
+        @include assert-equal(
+            $_o-fonts-families-included,
+            (
+                'MetricWeb-regular-normal': true,
+                'MetricWeb-semibold-normal': true,
+                'FinancierDisplayWeb-medium-normal': true,
+                'FinancierDisplayWeb-bold-normal': true,
+                'FinancierDisplayWeb-regular-normal': true
+            )
+        );
+        $_o-fonts-families-included: $original-o-fonts-families-included !global;
+	}
+}
+
 @include test-module('oFontsDefineCustomFont') {
 	@include test('Outputs the custom font face and updates the "$_o-fonts-families" map.') {
 
@@ -18,7 +99,7 @@
             }
         }
 
-        // The font faces are output.
+        // The custom font faces are recorded.
         @include assert-equal(
             $_o-fonts-families,
             ("MyFont": ("font-family": "MyFont, sans", "variants": ((weight: regular, style: normal), (weight: bold, style: normal)), "custom": true), MetricWeb: (font-family: "MetricWeb, sans-serif", variants: ((weight: thin, style: normal), (weight: light, style: normal), (weight: light, style: italic), (weight: regular, style: normal), (weight: regular, style: italic), (weight: medium, style: normal), (weight: semibold, style: normal), (weight: bold, style: normal), (weight: bold, style: italic))), FinancierDisplayWeb: (font-family: "FinancierDisplayWeb, serif", variants: ((weight: light, style: italic), (weight: regular, style: normal), (weight: regular, style: italic), (weight: medium, style: italic), (weight: medium, style: normal), (weight: semibold, style: italic), (weight: bold, style: normal))))


### PR DESCRIPTION
o-fonts allows Sass users to include any font face we have a font
file for. By default not all fonts are included via the build service
or using the `oFonts` mixin, so we don't deliver financier to the
internal brand. However most font styles/weights are output by
default so we don't limit Build Service users, who can not use
Sass to include extra fonts.

For performance ft.com and the app include a limited set of font
faces. Realistically, master brand Origami components can't use font
faces not included by these projects ([ft.com](https://github.com/Financial-Times/n-ui-foundations/blob/b530e18f9de605ee53a67f94db2deef27a910b6c/typography/main.scss#L5), [app](https://github.com/Financial-Times/ft-app/blob/4fd75f26efb9e107ae5f44fad8bae70a88443839/lib/css/fruit/globals/_fonts.scss#L12)).

We don't actually document what those font faces are however.
This commit documents this limited set of font faces as "recommended
fonts", and adds an option to the primary mixin.

For the master brand I have included "financier-display medium"
as it is just being introduced to teasers presently. I have not
included "metric medium" or "financier-display regular" as
there're active efforts to remove uses, but they could be included
in a future minor release.