### PR TITLE
Add function `oFontsVariantIncluded`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,23 @@ $allowed: oFontsVariantExists('MetricWeb', 'bold', 'normal'); // true
 $allowed: oFontsVariantExists('MetricWeb', 'black', 'italic'); // false
 ```
 
+### Check a font of weight or style has been included
+
+To check if a font weight/style has been output in your project use `oFontsVariantIncluded`.
+
+```scss
+// including fonts in project
+@include oFonts($opts: (
+	'metric': (
+        ('weight': 'medium', 'style': 'normal')
+    ),
+));
+
+
+$included: oFontsVariantIncluded('MetricWeb', 'medium', 'normal'); // true
+$included: oFontsVariantIncluded('MetricWeb', 'bold', 'normal'); // false
+```
+
 ## Contributing
 
 ### Add a new font or font variant

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -26,6 +26,23 @@
 	@return false;
 }
 
+/// Check if a font variant has been included
+/// in your project with the `oFonts` mixin.
+///
+/// @access public
+/// @param {String} $family - one of $_o-fonts-families
+/// @param {String} $weight [regular] - The font weight.
+/// @param {String} $style [normal] - The font style.
+/// @return {Bool}
+/// @see oFonts To include fonts
+@function oFontsVariantIncluded($family, $weight, $style) {
+	$weight: if($weight, $weight, 'regular'); // Handles a falsy `$weight` value.
+	$style: if($style, $style, 'normal'); // Handles a falsy `$style` value.
+	$variant-key: _oFontsVariantKey($family, $weight, $style);
+
+	@return map-has-key($_o-fonts-families-included, $variant-key);
+}
+
 /// Get a font-family stack with the appropriate fallbacks
 ///
 /// @example scss
@@ -86,4 +103,17 @@
 	$rest-of-string: str-slice($string, 2);
 
 	@return $first-letter + $rest-of-string;
+}
+
+
+/// For a font variant (family, weight, style) return
+/// a key to identify the variant.
+///
+/// @access private
+/// @param {String} $family - one of $_o-fonts-families
+/// @param {String} $weight [regular] - The font weight.
+/// @param {String} $style [normal] - The font style.
+/// @return {String} - the key
+@function _oFontsVariantKey($family, $weight, $style) {
+	@return "#{$family}-#{$weight}-#{$style}";
 }

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -68,7 +68,7 @@
 
 	// Check if the font has already been included
 	// If so, no need to output another @font-face declaration
-	$font-is-already-included: map-has-key($_o-fonts-families-included, #{$family}-#{$weight}-#{$style});
+	$font-is-already-included: oFontsVariantIncluded($family, $weight, $style);
 
 	@if $font-is-already-included == false {
 		// Error if a font does not exist for the given variant.
@@ -105,6 +105,7 @@
 		}
 
 		// Add to the list of already included families / variants
-		$_o-fonts-families-included: map-merge($_o-fonts-families-included, (#{$family}-#{$weight}-#{$style}: true)) !global;
+		$variant-key: _oFontsVariantKey($family, $weight, $style);
+		$_o-fonts-families-included: map-merge($_o-fonts-families-included, ($variant-key: true)) !global;
 	}
 }

--- a/test/scss/_functions.test.scss
+++ b/test/scss/_functions.test.scss
@@ -26,6 +26,43 @@
 	}
 }
 
+@include test-module('oFontsVariantIncluded') {
+	@include test('Returns false when no fonts have been included.') {
+        @include assert-equal(
+            oFontsVariantIncluded('MetricWeb', 'regular', 'normal'),
+            false
+        );
+	}
+	@include test('Returns true when the font has been included.') {
+        // The font faces are output.
+        // o-fonts keeps track of included fonts, so reset this
+        // private variable for each test :mask:
+        $original-o-fonts-families-included: $_o-fonts-families-included;
+        @include oFonts($opts: (
+        	'metric': ((weight: regular, style: normal),)
+        ));
+        @include assert-equal(
+            oFontsVariantIncluded('MetricWeb', 'regular', 'normal'),
+            true
+        );
+        $_o-fonts-families-included: $original-o-fonts-families-included !global;
+    }
+	@include test('Defaults to regular/normal for falsy weight/style.') {
+        // The font faces are output.
+        // o-fonts keeps track of included fonts, so reset this
+        // private variable for each test :mask:
+        $original-o-fonts-families-included: $_o-fonts-families-included;
+        @include oFonts($opts: (
+        	'metric': ((weight: regular, style: normal),)
+        ));
+        @include assert-equal(
+            oFontsVariantIncluded('MetricWeb', false, false),
+            true
+        );
+        $_o-fonts-families-included: $original-o-fonts-families-included !global;
+    }
+}
+
 @include test-module('oFontsGetFontFamilyWithoutFallbacks') {
 	@include test('Does nothing to a font family which has no fallback') {
         @include assert-equal(


### PR DESCRIPTION
`oFontsVariantIncluded` checks a font variant has been output.
It has the same parameters as `oFontsVariantExists`, which
checks a font variant is available to include.

https://github.com/Financial-Times/o-fonts/issues/109