### PR TITLE
Add `oFontsVariantsIncluded` mixin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ For example to include recommended fonts used by Origami components and an extra
 ));
 ```
 
+_Note: If your project has multiple Sass entry points call `oFontsVariantsIncluded` with the same options as `oFonts`, to tell `o-fonts` which font faces have been output._
+
 ### Font Loading
 
 By default [font-display](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display) is set to `swap`. In supporting browsers a system font is shown until fonts are loaded. To update your font loading method set `$o-fonts-display` at the top of your Sass, before including any other component.
@@ -189,6 +191,8 @@ To check if a font weight/style has been output in your project use `oFontsVaria
 $included: oFontsVariantIncluded('MetricWeb', 'medium', 'normal'); // true
 $included: oFontsVariantIncluded('MetricWeb', 'bold', 'normal'); // false
 ```
+
+_Note: If your project has multiple Sass entry points call `oFontsVariantsIncluded` with the same options as `oFonts`, to tell `o-fonts` which font faces have been output._
 
 ## Contributing
 

--- a/main.scss
+++ b/main.scss
@@ -37,39 +37,15 @@
 ///     	'metric': ((weight: regular, style: normal)),
 ///     	'financier-display': ((weight: regular, style: normal))
 ///     ));
+/// @param {Map} $opts - the font faces to included, see the README or examples for more details.
 @mixin oFonts($opts: $_o-fonts-default) {
-	// Map of options to font name.
-	$fonts: (
-		'metric': 'MetricWeb',
-		'financier-display': 'FinancierDisplayWeb'
-	);
-	// Include each font variant given.
-	@each $option, $family in $fonts {
-		// Get font variants to include from the opt map by font family.
-		$variants: map-get($opts, $option);
-		$variants: if($variants, $variants, ());
-		// Merge recommended font variants if recommended fonts were requested.
-		@if map-get($opts, 'recommended') == true {
-			$recommended-variants: map-get($_o-fonts-recommended, $option);
-			@if length($variants) > 0 {
-				$variants: append($recommended-variants, $variants);
-			} @else {
-				$variants: $recommended-variants;
-			}
-		}
-		@each $variant in $variants {
-			// Validate that the variant style and weight is given.
-			$weight: map-get($variant, 'weight');
-			$style: map-get($variant, 'style');
-			@if(type-of($weight) != 'string') {
-				@error 'Could not include the "#{$family}" font with weight "#{inspect($weight)}". Excepted a string.';
-			}
-			@if(type-of($style) != 'string') {
-				@error 'Could not include the "#{$family}" font with style "#{inspect($style)}". Excepted a string.';
-			}
-			// Include the font face for this variant.
-			@include _oFontsInclude($family, $weight, $style);
-		}
+	$variants: _oFontsOptionsToVariants($opts);
+
+	@each $variant in $variants {
+		$family: map-get($variant, 'family');
+		$weight: map-get($variant, 'weight');
+		$style: map-get($variant, 'style');
+		@include _oFontsInclude($family, $weight, $style);
 	}
 }
 

--- a/main.scss
+++ b/main.scss
@@ -37,7 +37,7 @@
 ///     	'metric': ((weight: regular, style: normal)),
 ///     	'financier-display': ((weight: regular, style: normal))
 ///     ));
-/// @param {Map} $opts - the font faces to included, see the README or examples for more details.
+/// @param {Map} $opts - the font faces to include, see the README or examples for more details.
 @mixin oFonts($opts: $_o-fonts-default) {
 	$variants: _oFontsOptionsToVariants($opts);
 

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -117,3 +117,49 @@
 @function _oFontsVariantKey($family, $weight, $style) {
 	@return "#{$family}-#{$weight}-#{$style}";
 }
+
+/// Given an o-fonts options map, return a list of variant maps e.g.
+/// (('family': 'MetricWeb', 'weight': 'regular', 'style': 'normal'),
+/// ('family': 'FinancierDisplayWeb', 'weight': 'bold', 'style': 'normal'))
+/// @param {Maps} $opts - An o-fonts options map (see `oFonts` and `oFontsVariantsIncluded`)
+/// @return {List} - A list of font variant maps, which include 'family', 'weight', and 'style'.
+@function _oFontsOptionsToVariants($opts) {
+	$all-validated-variants: ();
+	// Map of options to font name.
+	$fonts: (
+		'metric': 'MetricWeb',
+		'financier-display': 'FinancierDisplayWeb'
+	);
+	// Include each font variant given.
+	@each $option, $family in $fonts {
+		// Get font variants to include from the opt map by font family.
+		$variants: map-get($opts, $option);
+		$variants: if($variants, $variants, ());
+		// Merge recommended font variants if recommended fonts were requested.
+		@if map-get($opts, 'recommended') == true {
+			$recommended-variants: map-get($_o-fonts-recommended, $option);
+			@if length($variants) > 0 {
+				$variants: append($recommended-variants, $variants);
+			} @else {
+				$variants: $recommended-variants;
+			}
+		}
+		@each $variant in $variants {
+			// Validate that the variant style and weight is given.
+			$weight: map-get($variant, 'weight');
+			$style: map-get($variant, 'style');
+			@if(type-of($weight) != 'string') {
+				@error 'Could not include the "#{$family}" font with weight "#{inspect($weight)}". Excepted a string.';
+			}
+			@if(type-of($style) != 'string') {
+				@error 'Could not include the "#{$family}" font with style "#{inspect($style)}". Excepted a string.';
+			}
+			// Include the font face for this variant.
+			$all-validated-variants: append(
+				$all-validated-variants,
+				('family': $family, 'weight': $weight, 'style': $style)
+			);
+		}
+	}
+	@return $all-validated-variants;
+}

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -44,6 +44,54 @@
 	@content; // Output a custom Font-face declaration.
 }
 
+/// Register which fonts have been output by already for your project.
+/// This mixin is useful if a project calls the `oFonts` mixin is in a different
+/// entry point.
+///
+/// @example Include all fonts for the current brand (master, internal, whitelabel).
+///     @include oFontsVariantsIncluded();
+///
+/// @example Include a limited set of recommended fonts for the current brand (master, internal, whitelabel).
+///     @include oFontsVariantsIncluded($opts: ('recommended': true));
+///
+/// @example Include a limited set of recommended fonts for the current brand, plus an extra FinancierDisplayWeb font.
+/// 	@include oFontsVariantsIncluded($opts: (
+/// 		'recommended': true,
+/// 		'financier-display': (
+/// 			(weight: regular, style: normal)
+/// 		)
+/// 	));
+///
+/// @example Include only regular and semibold MetricWeb font faces.
+///     @include oFontsVariantsIncluded($opts: ('metric': (
+///     	(weight: regular, style: normal),
+///     	(weight: semibold, style: normal),
+///     )));
+///
+/// @example Include only regular and bold FinancierDisplayWeb font faces.
+///     @include oFontsVariantsIncluded($opts: ('financier-display': (
+///     	(weight: regular, style: normal),
+///     	(weight: semibold, style: normal),
+///     )));
+///
+/// @example Include only regular font faces for MetricWeb and FinancierDisplayWeb.
+///     @include oFontsVariantsIncluded($opts: (
+///     	'metric': ((weight: regular, style: normal)),
+///     	'financier-display': ((weight: regular, style: normal))
+///     ));
+/// @param {Map} $opts - the font faces to included, see the README or examples for more details.
+/// @see oFonts - Use `oFonts` to include font faces.
+@mixin oFontsVariantsIncluded($opts: $_o-fonts-default) {
+	$variants: _oFontsOptionsToVariants($opts);
+
+	@each $variant in $variants {
+		$family: map-get($variant, 'family');
+		$weight: map-get($variant, 'weight');
+		$style: map-get($variant, 'style');
+		@include _oFontsVariantIncluded($family, $weight, $style);
+	}
+}
+
 /// Output a Font-face declaration for a given font family which is provided by Origami.
 ///
 /// @param {String} $family - one of $_o-fonts-families
@@ -105,7 +153,17 @@
 		}
 
 		// Add to the list of already included families / variants
-		$variant-key: _oFontsVariantKey($family, $weight, $style);
-		$_o-fonts-families-included: map-merge($_o-fonts-families-included, ($variant-key: true)) !global;
+		@include _oFontsVariantIncluded($family, $weight, $style);
 	}
+}
+
+/// Log a given font variant as having been output.
+///
+/// @param {String} $family - one of $_o-fonts-families
+/// @param {String} $weight [regular] - The font weight.
+/// @param {String} $style [normal] - The font style.
+@mixin _oFontsVariantIncluded($family, $weight, $style) {
+	// Add to the list of already included families / variants
+	$variant-key: _oFontsVariantKey($family, $weight, $style);
+	$_o-fonts-families-included: map-merge($_o-fonts-families-included, ($variant-key: true)) !global;
 }

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -52,9 +52,90 @@
         $_o-fonts-families-included: $original-o-fonts-families-included !global;
 	}
 
-	@include test('Includes recommended fonts and specified addition fonts') {
+	@include test('Includes recommended fonts and specified additional fonts') {
 
         @include oFonts($opts: (
+        	'recommended': true,
+        	'financier-display': (
+        		(weight: regular, style: normal) // extra font, not a recommended font
+        	)
+        ));
+
+        // The font faces are output.
+        // o-fonts keeps track of included fonts, we can't test font-faces
+        // with true-sass so test against this private variable and reset
+        // it for each test :mask:
+        @include assert-equal(
+            $_o-fonts-families-included,
+            (
+                'MetricWeb-regular-normal': true,
+                'MetricWeb-semibold-normal': true,
+                'FinancierDisplayWeb-medium-normal': true,
+                'FinancierDisplayWeb-bold-normal': true,
+                'FinancierDisplayWeb-regular-normal': true
+            )
+        );
+        $_o-fonts-families-included: $original-o-fonts-families-included !global;
+	}
+}
+
+@include test-module('oFontsVariantsIncluded') {
+    $original-o-fonts-families-included: $_o-fonts-families-included;
+	@include test('Marks default fonts as having been included when given no options') {
+
+       @include oFontsVariantsIncluded();
+
+        // The font faces are output.
+        // o-fonts keeps track of included fonts, we can't test font-faces
+        // with true-sass so test against this private variable and reset
+        // it for each test :mask:
+        @include assert-equal(
+            $_o-fonts-families-included,
+            (
+                'MetricWeb-thin-normal': true,
+                'MetricWeb-light-normal': true,
+                'MetricWeb-light-italic': true,
+                'MetricWeb-regular-normal': true,
+                'MetricWeb-regular-italic': true,
+                'MetricWeb-medium-normal': true,
+                'MetricWeb-semibold-normal': true,
+                'MetricWeb-bold-normal': true,
+                'MetricWeb-bold-italic': true,
+                'FinancierDisplayWeb-light-italic': true,
+                'FinancierDisplayWeb-regular-normal': true,
+                'FinancierDisplayWeb-regular-italic': true,
+                'FinancierDisplayWeb-medium-italic': true,
+                'FinancierDisplayWeb-medium-normal': true,
+                'FinancierDisplayWeb-semibold-italic': true,
+                'FinancierDisplayWeb-bold-normal': true
+            )
+        );
+        $_o-fonts-families-included: $original-o-fonts-families-included !global;
+    }
+
+	@include test('Marks recommended fonts as having been included only when "recommended" option given') {
+
+       @include oFontsVariantsIncluded(('recommended': true));
+
+        // The font faces are output.
+        // o-fonts keeps track of included fonts, we can't test font-faces
+        // with true-sass so test against this private variable and reset
+        // it for each test :mask:
+        @include assert-equal(
+            $_o-fonts-families-included,
+            (
+                'MetricWeb-regular-normal': true,
+                'MetricWeb-semibold-normal': true,
+                'FinancierDisplayWeb-medium-normal': true,
+                'FinancierDisplayWeb-bold-normal': true
+            )
+        );
+        $_o-fonts-families-included: $original-o-fonts-families-included !global;
+	}
+
+	@include test('Marks recommended fonts as having been included and specified additional fonts') {
+
+        @include oFontsVariantsIncluded($opts: (
         	'recommended': true,
         	'financier-display': (
         		(weight: regular, style: normal) // extra font, not a recommended font


### PR DESCRIPTION
`o-fonts` provides a function to check which fonts a project has
output `oFontsVariantIncluded`. However some projects use multiple
Sass entry points. If fonts are output in a different entry point
using the `oFonts` mixin `oFontsVariantIncluded` will incorrectly
return `false`.

 `oFontsVariantsIncluded` mixin allows the project to tell `o-fonts`
which font variants have already been output in a different enrty
point (without actually outputting the font faces for a second time).

Relates to https://github.com/Financial-Times/o-fonts/issues/109