### PR TITLE
Map a "light" font weight to `300 instead of `200`

### DIFF
--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -113,7 +113,7 @@ $_o-fonts-families: (
 /// @access private
 $_o-fonts-weights: (
 	'thin':       100,
-	'light':      200,
+	'light':      300,
 	'regular':    400,
 	'normal':     400,
 	'medium':     500,


### PR DESCRIPTION
This is inline with the OpenType specifications "commonly-used values" and
the variable fonts commissioned for Financier display.

This should not be a breaking change:
- The api doesn't change. It is not visually breaking if using `o-typography`
or `oFontsWeight`, only if setting `font-weight: 200` directly.
- MetricWeb light is not used often (not on ft.com, not knowingly elsewhere)

Variable fonts proposal:
https://github.com/Financial-Times/origami/pull/75

OpenType specifications "commonly-used values":
https://docs.microsoft.com/en-us/typography/opentype/spec/os2#usweightclass

Closes: https://github.com/Financial-Times/o-fonts/issues/132