### PR TITLE
Add FinancierDisplayWeb Light/Semibold support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ A selection wider than [recommended fonts](#recommended-fonts) are included by d
 
 ## All Available Fonts
 
-Any of the below fonts may be included with `o-fonts` using [SASS](#sass), this is usual for brands such as specialist titles who may use additional fonts. Build Service users are limited to [fonts included by default](#fonts-included-by-default).
+Any of the below fonts may be included with `o-fonts` using [SASS](#sass), this is useful for brands such as specialist titles who may use additional fonts. Build Service users are limited to [fonts included by default](#fonts-included-by-default).
 
 | Weight   | FinancierDisplayWeb | FinancierTextWeb    | MetricWeb |
 |----------|:-------------------:|:-------------------:|:---------:|

--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ Any of the below fonts may be included with `o-fonts` using [SASS](#sass). Build
 | Weight   | FinancierDisplayWeb | MetricWeb |
 |----------|:-------------------:|:---------:|
 | thin     |                     |    ✓      |
-| light    |           i         |    ✓ i    |
+| light    |         ✓ i         |    ✓ i    |
 | regular  |         ✓ i         |    ✓ i    |
 | medium   |         ✓ i         |    ✓      |
-| semibold |           i         |    ✓      |
+| semibold |         ✓ i         |    ✓      |
 | bold     |         ✓           |    ✓ i    |
 | black    |                     |           |
 

--- a/README.md
+++ b/README.md
@@ -68,17 +68,17 @@ A selection wider than [recommended fonts](#recommended-fonts) are included by d
 
 ## All Available Fonts
 
-Any of the below fonts may be included with `o-fonts` using [SASS](#sass). Build Service users are limited to [fonts included by default](#fonts-included-by-default).
+Any of the below fonts may be included with `o-fonts` using [SASS](#sass), this is usual for brands such as specialist titles who may use additional fonts. Build Service users are limited to [fonts included by default](#fonts-included-by-default).
 
-| Weight   | FinancierDisplayWeb | MetricWeb |
-|----------|:-------------------:|:---------:|
-| thin     |                     |    ✓      |
-| light    |         ✓ i         |    ✓ i    |
-| regular  |         ✓ i         |    ✓ i    |
-| medium   |         ✓ i         |    ✓      |
-| semibold |         ✓ i         |    ✓      |
-| bold     |         ✓           |    ✓ i    |
-| black    |                     |           |
+| Weight   | FinancierDisplayWeb | FinancierTextWeb    | MetricWeb |
+|----------|:-------------------:|:-------------------:|:---------:|
+| thin     |                     |                     |    ✓      |
+| light    |         ✓ i         |                     |    ✓ i    |
+| regular  |         ✓ i         |                     |    ✓ i    |
+| medium   |         ✓ i         |          ✓          |    ✓      |
+| semibold |         ✓ i         |                     |    ✓      |
+| bold     |         ✓           |          ✓          |    ✓ i    |
+| black    |         ✓           |          ✓          |    ✓      |
 
 - **✓**: normal style available
 - **i**: italic style available (if not, faux-italic will be displayed)
@@ -100,7 +100,7 @@ To improve site performance, Origami components use a more limited set of font f
 @include oFonts($opts: ('recommended': true));
 ```
 
-You may also include specific fonts granularly using an options `$opts` map. The map has a key for each font `metric` or `financier-display`, which accepts a list of weight and styles to include.
+You may also include specific fonts granularly using an options `$opts` map. The map has a key for each font `metric`, `financier-display`, or `financier-text`, which accepts a list of weight and styles to include.
 
 For example to include recommended fonts used by Origami components and an extra font, `MetricWeb` in a medium weight, and regular `FinancierDisplayWeb`:
 ```scss

--- a/main.scss
+++ b/main.scss
@@ -37,6 +37,13 @@
 ///     	'metric': ((weight: regular, style: normal)),
 ///     	'financier-display': ((weight: regular, style: normal))
 ///     ));
+///
+/// @example Include only black weighted font faces for MetricWeb, FinancierDisplayWeb, and FinancierTextWeb.
+///     @include oFonts($opts: (
+///     	'metric': ((weight: 'black', style: normal)),
+///     	'financier-display': ((weight: 'black', style: normal)),
+///     	'financier-text': ((weight: 'black', style: normal))
+///     ));
 /// @param {Map} $opts - the font faces to include, see the README or examples for more details.
 @mixin oFonts($opts: $_o-fonts-default) {
 	$variants: _oFontsOptionsToVariants($opts);

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -128,7 +128,8 @@
 	// Map of options to font name.
 	$fonts: (
 		'metric': 'MetricWeb',
-		'financier-display': 'FinancierDisplayWeb'
+		'financier-display': 'FinancierDisplayWeb',
+		'financier-text': 'FinancierTextWeb',
 	);
 	// Include each font variant given.
 	@each $option, $family in $fonts {

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -6,7 +6,7 @@ $o-fonts-is-silent: true !default;
 /// Path to default font files.
 ///
 /// @type String
-$o-fonts-path: 'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.6.0/' !default;
+$o-fonts-path: 'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.7.0/' !default;
 
 /// The default `font-display` property of included font faces.
 /// https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display
@@ -18,30 +18,41 @@ $o-fonts-display: swap !default;
 /// @type List
 /// @access private
 $_o-fonts-all-metric-variants: (
-	(weight: thin, style: normal),
-	(weight: light, style: normal),
-	(weight: light, style: italic),
-	(weight: regular, style: normal),
-	(weight: regular, style: italic),
-	(weight: medium, style: normal),
-	(weight: semibold, style: normal),
-	(weight: bold, style: normal),
-	(weight: bold, style: italic),
+	(weight: 'thin', style: normal),
+	(weight: 'light', style: normal),
+	(weight: 'light', style: italic),
+	(weight: 'regular', style: normal),
+	(weight: 'regular', style: italic),
+	(weight: 'medium', style: normal),
+	(weight: 'semibold', style: normal),
+	(weight: 'bold', style: normal),
+	(weight: 'bold', style: italic),
+	(weight: 'black', style: normal)
 );
 
 /// A list of all weight and style variants of the FinancierDisplayWeb font.
 /// @type List
 /// @access private
 $_o-fonts-all-financier-display-variants: (
-	(weight: light, style: normal),
-	(weight: light, style: italic),
-	(weight: regular, style: normal),
-	(weight: regular, style: italic),
-	(weight: medium, style: italic),
-	(weight: medium, style: normal),
-	(weight: semibold, style: normal),
-	(weight: semibold, style: italic),
-	(weight: bold, style: normal)
+	(weight: 'light', style: normal),
+	(weight: 'light', style: italic),
+	(weight: 'regular', style: normal),
+	(weight: 'regular', style: italic),
+	(weight: 'medium', style: italic),
+	(weight: 'medium', style: normal),
+	(weight: 'semibold', style: normal),
+	(weight: 'semibold', style: italic),
+	(weight: 'bold', style: normal),
+	(weight: 'black', style: normal)
+);
+
+/// A list of all weight and style variants of the FinancierTextWeb font.
+/// @type List
+/// @access private
+$_o-fonts-all-financier-text-variants: (
+	(weight: 'medium', style: normal),
+	(weight: 'bold', style: normal),
+	(weight: 'black', style: normal)
 );
 
 /// The fonts to include by default, which vary per brand.
@@ -68,7 +79,8 @@ $_o-fonts-default: ();
 /// @access private
 $_o-fonts-recommended: (
 	'metric': (),
-	'financier-display': ()
+	'financier-display': (),
+	'financier-text': ()
 );
 
 @if oBrandGetCurrentBrand() == 'master' {
@@ -80,7 +92,8 @@ $_o-fonts-recommended: (
 		'financier-display': (
 			(weight: medium, style: normal),
 			(weight: bold, style: normal)
-		)
+		),
+		'financier-text': ()
 	);
 }
 
@@ -90,7 +103,8 @@ $_o-fonts-recommended: (
 			(weight: regular, style: normal),
 			(weight: semibold, style: normal)
 		),
-		'financier-display': ()
+		'financier-display': (),
+		'financier-text': ()
 	);
 }
 
@@ -106,6 +120,10 @@ $_o-fonts-families: (
 	FinancierDisplayWeb: (
 		font-family: 'FinancierDisplayWeb, serif',
 		variants: $_o-fonts-all-financier-display-variants
+	),
+	FinancierTextWeb: (
+		font-family: 'FinancierTextWeb, serif',
+		variants: $_o-fonts-all-financier-text-variants
 	),
 ) !default;
 

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -6,7 +6,7 @@ $o-fonts-is-silent: true !default;
 /// Path to default font files.
 ///
 /// @type String
-$o-fonts-path: 'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.5.0/' !default;
+$o-fonts-path: 'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.6.0/' !default;
 
 /// The default `font-display` property of included font faces.
 /// https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display
@@ -33,11 +33,13 @@ $_o-fonts-all-metric-variants: (
 /// @type List
 /// @access private
 $_o-fonts-all-financier-display-variants: (
+	(weight: light, style: normal),
 	(weight: light, style: italic),
 	(weight: regular, style: normal),
 	(weight: regular, style: italic),
 	(weight: medium, style: italic),
 	(weight: medium, style: normal),
+	(weight: semibold, style: normal),
 	(weight: semibold, style: italic),
 	(weight: bold, style: normal)
 );

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -139,7 +139,7 @@ $_o-fonts-weights: (
 	'medium':     500,
 	'semibold':   600,
 	'bold':       700,
-	'black':      800,
+	'black':      900,
 ) !default;
 
 /// Map of families and styles which have already been included

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -57,7 +57,7 @@
 		@include oFonts($opts: (
 			'recommended': true,
 			'financier-display': (
-				(weight: regular, style: normal) 
+				(weight: regular, style: normal)
 			)
 		));
 
@@ -101,11 +101,13 @@
 				'MetricWeb-semibold-normal': true,
 				'MetricWeb-bold-normal': true,
 				'MetricWeb-bold-italic': true,
+				'FinancierDisplayWeb-light-normal': true,
 				'FinancierDisplayWeb-light-italic': true,
 				'FinancierDisplayWeb-regular-normal': true,
 				'FinancierDisplayWeb-regular-italic': true,
 				'FinancierDisplayWeb-medium-italic': true,
 				'FinancierDisplayWeb-medium-normal': true,
+				'FinancierDisplayWeb-semibold-normal': true,
 				'FinancierDisplayWeb-semibold-italic': true,
 				'FinancierDisplayWeb-bold-normal': true
 			)
@@ -138,7 +140,7 @@
 		@include oFontsVariantsIncluded($opts: (
 			'recommended': true,
 			'financier-display': (
-				(weight: regular, style: normal) 
+				(weight: regular, style: normal)
 			)
 		));
 
@@ -183,7 +185,7 @@
 		// The custom font faces are recorded.
 		@include assert-equal(
 			$_o-fonts-families,
-			("MyFont": ("font-family": "MyFont, sans", "variants": ((weight: regular, style: normal), (weight: bold, style: normal)), "custom": true), MetricWeb: (font-family: "MetricWeb, sans-serif", variants: ((weight: thin, style: normal), (weight: light, style: normal), (weight: light, style: italic), (weight: regular, style: normal), (weight: regular, style: italic), (weight: medium, style: normal), (weight: semibold, style: normal), (weight: bold, style: normal), (weight: bold, style: italic))), FinancierDisplayWeb: (font-family: "FinancierDisplayWeb, serif", variants: ((weight: light, style: italic), (weight: regular, style: normal), (weight: regular, style: italic), (weight: medium, style: italic), (weight: medium, style: normal), (weight: semibold, style: italic), (weight: bold, style: normal))))
+			("MyFont": ("font-family": "MyFont, sans", "variants": ((weight: regular, style: normal), (weight: bold, style: normal)), "custom": true), MetricWeb: (font-family: "MetricWeb, sans-serif", variants: ((weight: thin, style: normal), (weight: light, style: normal), (weight: light, style: italic), (weight: regular, style: normal), (weight: regular, style: italic), (weight: medium, style: normal), (weight: semibold, style: normal), (weight: bold, style: normal), (weight: bold, style: italic))), FinancierDisplayWeb: (font-family: "FinancierDisplayWeb, serif", variants: ((weight: light, style: normal), (weight: light, style: italic), (weight: regular, style: normal), (weight: regular, style: italic), (weight: medium, style: italic), (weight: medium, style: normal), (weight: semibold, style: normal), (weight: semibold, style: italic), (weight: bold, style: normal))))
 		);
 	}
 }

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -20,13 +20,17 @@
 				'MetricWeb-semibold-normal': true,
 				'MetricWeb-bold-normal': true,
 				'MetricWeb-bold-italic': true,
+				'MetricWeb-black-normal': true,
+				'FinancierDisplayWeb-light-normal': true,
 				'FinancierDisplayWeb-light-italic': true,
 				'FinancierDisplayWeb-regular-normal': true,
 				'FinancierDisplayWeb-regular-italic': true,
 				'FinancierDisplayWeb-medium-italic': true,
 				'FinancierDisplayWeb-medium-normal': true,
+				'FinancierDisplayWeb-semibold-normal': true,
 				'FinancierDisplayWeb-semibold-italic': true,
-				'FinancierDisplayWeb-bold-normal': true
+				'FinancierDisplayWeb-bold-normal': true,
+				'FinancierDisplayWeb-black-normal': true
 			)
 		);
 		$_o-fonts-families-included: $original-o-fonts-families-included !global;
@@ -57,7 +61,10 @@
 		@include oFonts($opts: (
 			'recommended': true,
 			'financier-display': (
-				(weight: regular, style: normal)
+				(weight: 'regular', style: normal)
+			),
+			'financier-text': (
+				(weight: 'black', style: normal)
 			)
 		));
 
@@ -72,7 +79,8 @@
 				'MetricWeb-semibold-normal': true,
 				'FinancierDisplayWeb-medium-normal': true,
 				'FinancierDisplayWeb-bold-normal': true,
-				'FinancierDisplayWeb-regular-normal': true
+				'FinancierDisplayWeb-regular-normal': true,
+				'FinancierTextWeb-black-normal': true
 			)
 		);
 		$_o-fonts-families-included: $original-o-fonts-families-included !global;
@@ -101,6 +109,7 @@
 				'MetricWeb-semibold-normal': true,
 				'MetricWeb-bold-normal': true,
 				'MetricWeb-bold-italic': true,
+				'MetricWeb-black-normal': true,
 				'FinancierDisplayWeb-light-normal': true,
 				'FinancierDisplayWeb-light-italic': true,
 				'FinancierDisplayWeb-regular-normal': true,
@@ -109,7 +118,8 @@
 				'FinancierDisplayWeb-medium-normal': true,
 				'FinancierDisplayWeb-semibold-normal': true,
 				'FinancierDisplayWeb-semibold-italic': true,
-				'FinancierDisplayWeb-bold-normal': true
+				'FinancierDisplayWeb-bold-normal': true,
+				'FinancierDisplayWeb-black-normal': true
 			)
 		);
 		$_o-fonts-families-included: $original-o-fonts-families-included !global;
@@ -185,7 +195,7 @@
 		// The custom font faces are recorded.
 		@include assert-equal(
 			$_o-fonts-families,
-			("MyFont": ("font-family": "MyFont, sans", "variants": ((weight: regular, style: normal), (weight: bold, style: normal)), "custom": true), MetricWeb: (font-family: "MetricWeb, sans-serif", variants: ((weight: thin, style: normal), (weight: light, style: normal), (weight: light, style: italic), (weight: regular, style: normal), (weight: regular, style: italic), (weight: medium, style: normal), (weight: semibold, style: normal), (weight: bold, style: normal), (weight: bold, style: italic))), FinancierDisplayWeb: (font-family: "FinancierDisplayWeb, serif", variants: ((weight: light, style: normal), (weight: light, style: italic), (weight: regular, style: normal), (weight: regular, style: italic), (weight: medium, style: italic), (weight: medium, style: normal), (weight: semibold, style: normal), (weight: semibold, style: italic), (weight: bold, style: normal))))
+			("MyFont": ("font-family": "MyFont, sans", "variants": ((weight: regular, style: normal), (weight: bold, style: normal)), "custom": true), MetricWeb: (font-family: "MetricWeb, sans-serif", variants: ((weight: "thin", style: normal), (weight: "light", style: normal), (weight: "light", style: italic), (weight: "regular", style: normal), (weight: "regular", style: italic), (weight: "medium", style: normal), (weight: "semibold", style: normal), (weight: "bold", style: normal), (weight: "bold", style: italic), (weight: "black", style: normal))), FinancierDisplayWeb: (font-family: "FinancierDisplayWeb, serif", variants: ((weight: "light", style: normal), (weight: "light", style: italic), (weight: "regular", style: normal), (weight: "regular", style: italic), (weight: "medium", style: italic), (weight: "medium", style: normal), (weight: "semibold", style: normal), (weight: "semibold", style: italic), (weight: "bold", style: normal), (weight: "black", style: normal))), FinancierTextWeb: (font-family: "FinancierTextWeb, serif", variants: ((weight: "medium", style: normal), (weight: "bold", style: normal), (weight: "black", style: normal))))
 		);
 	}
 }


### PR DESCRIPTION
Adds:

- MetricWeb Black
- FinancierDisplayWeb Light
- FinancierDisplayWeb Semibold
- FinancierDisplayWeb Black
- FinancierTextWeb Medium
- FinancierTextWeb Bold
- FinancierTextWeb Black

For backward compatibility MetricWeb and FinancierDisplayWeb variants are
output when no options are specified for the master brand. All MetricWeb are
output when no options are specified for the internal brand. In keeping with
this the new weights for these fonts will be output when no options are
specified:
```scss
@import 'o-fonts/main';
@include oFonts();
```

However there is no change when requesting the recommended font set for
master/internal products:
```scss
@import 'o-fonts/main';
@include oFonts($opts: ('recommended': true));
```

The new FinancierTextWeb fonts, added for specialist titles, will not be
output unless specifically asked for, e.g:
```scss
@import 'o-fonts/main';
@include oFonts($opts: (
	'metric': (
		(weight: 'black', style: normal)
	),
	'financier-text': (
                (weight: 'medium', style: normal),
                (weight: 'bold', style: normal),
                (weight: 'black', style: normal)
	)
));
```

Related specialist components PR: Financial-Times/specialist-components#275