### PR TITLE
allow newer versions of o-brand v4 to be used

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,7 +2,6 @@
 node_modules
 demos/local
 build/
-demos/*.html
 .eslintrc.cjs
 .github
 .gitignore

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"stylelint-config-origami-component": "^1.0.4"
 	},
 	"peerDependencies": {
-		"@financial-times/o-brand": "4.0.2"
+		"@financial-times/o-brand": "^4.0.2"
 	},
 	"engines": {
 		"npm": "^7"


### PR DESCRIPTION
This was discovered when working on moving all components to a mono-repo